### PR TITLE
switch container image upstream to ECR

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/python:3.12
+FROM public.ecr.aws/docker/library/python:3.12.9
 ARG release
 WORKDIR /app
 COPY requirements.txt /app/requirements.txt

--- a/config/docker/simple-proxy/Containerfile
+++ b/config/docker/simple-proxy/Containerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.21-alpine
+FROM public.ecr.aws/docker/library/python:3.9.21-alpine
 RUN apk add --no-cache py3-pip
 RUN python3 -m venv /app
 ENV PATH="/app/bin:$PATH"


### PR DESCRIPTION
Docker Hub imposes pull limits which we finally hit and caused build failures. Switch to something else more reasonable.