### PR TITLE
fix: correctness bugs in the ingest path, bot and gateway management

### DIFF
--- a/bridger/bot.py
+++ b/bridger/bot.py
@@ -1,4 +1,5 @@
 import os
+from typing import Optional
 
 from aiohttp import ClientConnectorError
 from discord import Intents
@@ -7,12 +8,24 @@ from discord.ext import commands
 from bridger.influx import create_influx_client
 from bridger.log import logger
 
-try:
-    DISCORD_BOT_TOKEN = os.getenv("DISCORD_BOT_TOKEN")
-    DISCORD_BOT_OWNER_ID = int(os.getenv("DISCORD_BOT_OWNER_ID"))
-except TypeError as e:
-    logger.error(f"Failed to load environment variable {e}")
-    exit(1)
+
+def get_owner_id() -> Optional[int]:
+    """Read DISCORD_BOT_OWNER_ID, tolerating it being unset or blank.
+
+    .env.default ships this as an empty string, and int("") raises ValueError rather than the
+    TypeError that unset produces, so the bot used to die on its own documented default.
+    """
+    raw = (os.getenv("DISCORD_BOT_OWNER_ID") or "").strip()
+
+    if not raw:
+        logger.warning("DISCORD_BOT_OWNER_ID is not set, owner-only commands will be unavailable")
+        return None
+
+    try:
+        return int(raw)
+    except ValueError:
+        logger.error(f"DISCORD_BOT_OWNER_ID is not an integer: {raw!r}")
+        return None
 
 
 class BridgerBot(commands.Bot):
@@ -33,18 +46,7 @@ class BridgerBot(commands.Bot):
             logger.info(f"Loaded extension: {ext}")
 
 
-intents = Intents.default()
-intents.message_content = True
-intents.members = True
-
-bot = BridgerBot(
-    intents=intents,
-    owner_id=DISCORD_BOT_OWNER_ID,
-)
-
-
 @commands.is_owner()
-@bot.command(name="sync-commands", description="Sync the commands with the database")
 async def sync_commands(ctx: commands.Context):
     try:
         await ctx.bot.tree.sync()
@@ -53,8 +55,32 @@ async def sync_commands(ctx: commands.Context):
         await ctx.send(f"Error syncing commands: {e}")
 
 
-try:
-    bot.run(DISCORD_BOT_TOKEN)
-except ClientConnectorError as e:
-    logger.error(f"Failed to connect to Discord {e}")
-    exit(1)
+def create_bot() -> BridgerBot:
+    intents = Intents.default()
+    intents.message_content = True
+    intents.members = True
+
+    bot = BridgerBot(intents=intents, owner_id=get_owner_id())
+    bot.command(name="sync-commands", description="Sync the commands with the database")(sync_commands)
+
+    return bot
+
+
+def main() -> int:
+    token = os.getenv("DISCORD_BOT_TOKEN")
+
+    if not token:
+        logger.error("DISCORD_BOT_TOKEN is not set, cannot start the bot")
+        return 1
+
+    try:
+        create_bot().run(token)
+    except ClientConnectorError as e:
+        logger.error(f"Failed to connect to Discord {e}")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bridger/cogs/mqtt.py
+++ b/bridger/cogs/mqtt.py
@@ -326,7 +326,7 @@ class MQTTCog(commands.GroupCog, name="bridger-mqtt"):
     @app_commands.command(name="reset-password", description="Reset MQTT account password")
     @app_commands.autocomplete(node_id=node_id_autocomplete)
     async def reset_password(self, ctx: Interaction, node_id: str):
-        gateway, password = self.gateway_manager.reset_gateway_password(node_id, ctx.user)
+        gateway, password = self.gateway_manager.reset_gateway_password(node_id)
 
         await ctx.response.send_message(
             f"Gateway **{gateway.node_hex_id_without_bang}** password reset. The username is **{gateway.user_string}** with new password: `{password}`",  # noqa: E501

--- a/bridger/cogs/testmsg.py
+++ b/bridger/cogs/testmsg.py
@@ -20,6 +20,7 @@ from bridger.log import logger
 from bridger.mqtt import PBPacketProcessor
 from bridger.utils import should_ignore_pki_message
 
+DEFAULT_EMBED_COLOR = 0x5865F2  # Discord blurple, used when the gateway id will not parse
 MQTT_TEST_CHANNEL_MESHTASTIC = os.getenv("MQTT_TEST_CHANNEL", "+")
 MQTT_TEST_CHANNEL_DISCORD = int(os.getenv("MQTT_TEST_CHANNEL_ID", 1253788609316913265))
 TEST_MESSAGE_MATCHERS = [
@@ -60,8 +61,7 @@ class TestMsg(commands.GroupCog, name="testmsg"):
 
     def create_embed(self, service_envelope: ServiceEnvelope):
         packet = service_envelope.packet
-        gateway = service_envelope.gateway_id
-        color = int(gateway[-6:], 16)
+        gateway = service_envelope.gateway_id or ""
         snr = packet.rx_snr
         rssi = packet.rx_rssi
         hop_count = None
@@ -71,19 +71,29 @@ class TestMsg(commands.GroupCog, name="testmsg"):
         if packet.hop_start > 0:
             hop_count = packet.hop_start - packet.hop_limit
 
-        embed = Embed(color=color)
-        # Try to get node info for the gateway hex ID
+        # Parse the gateway id exactly once. Everything below degrades to a default rather
+        # than raising: this runs inside the MQTT loop, where an exception drops the message.
         gateway_id = None
         node_info = None
 
         try:
-            gateway_id = int(gateway.strip("!"), 16)
-            node_info = self.influx_reader.get_node_info(gateway_id)
+            gateway_id = int(gateway.lstrip("!"), 16)
         except (ValueError, TypeError) as e:
-            logger.error(f"Failed to parse gateway ID '{gateway}': {e}")
+            logger.warning(f"Failed to parse gateway ID '{gateway}': {e}")
+        else:
+            try:
+                node_info = self.influx_reader.get_node_info(gateway_id)
+            except Exception:
+                logger.exception(f"Failed to look up node info for gateway {gateway}")
 
-        node_id = gateway_id if gateway_id is not None else int(gateway, 16)
-        gateway_name = self.format_node_name(node_id, node_info)
+        if gateway_id is None:
+            color = DEFAULT_EMBED_COLOR
+            gateway_name = f"**{gateway or 'unknown'}**"
+        else:
+            color = gateway_id & 0xFFFFFF
+            gateway_name = self.format_node_name(gateway_id, node_info)
+
+        embed = Embed(color=color)
         embed.description = f"Heard by {gateway_name} - `{gateway}` at {formatted_time}"
         embed.add_field(name="SNR", value=snr, inline=True)
         embed.add_field(name="RSSI", value=rssi, inline=True)

--- a/bridger/crypto.py
+++ b/bridger/crypto.py
@@ -5,7 +5,9 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 MAX_BLOCKSIZE = 1024
-MESHTASTIC_KEY = os.getenv("MESHTASTIC_KEY", "1PG7OiApB1nwvP+rz05pAQ==")  # Base64-encoded 32-byte key when set to AQ==
+# Base64-encoded 16-byte AES-128 key. The default is the Meshtastic default channel PSK,
+# which is what the "AQ==" shorthand expands to.
+MESHTASTIC_KEY = os.getenv("MESHTASTIC_KEY", "1PG7OiApB1nwvP+rz05pAQ==")
 
 
 class CryptoEngine:

--- a/bridger/dataclasses.py
+++ b/bridger/dataclasses.py
@@ -98,7 +98,7 @@ class PositionPoint(TelemetryPoint):
 
     latitude_i: int = field(metadata={"influx_kind": "field"})
     longitude_i: int = field(metadata={"influx_kind": "field"})
-    gps_time: Optional[str] = field(default=None, metadata={"influx_kind": "field"})
+    gps_time: Optional[int] = field(default=None, metadata={"influx_kind": "field"})
     precision_bits: Optional[int] = field(default=None, metadata={"influx_kind": "field"})
     altitude: Optional[int] = field(default=None, metadata={"influx_kind": "field"})
     PDOP: Optional[int] = field(default=None, metadata={"influx_kind": "field"})

--- a/bridger/gateway.py
+++ b/bridger/gateway.py
@@ -2,7 +2,6 @@ import os
 import re
 import secrets
 import string
-from collections.abc import Generator
 from dataclasses import dataclass
 from typing import Union
 
@@ -45,7 +44,7 @@ class GatewayManagerEMQX:
         self.emqx = emqx
 
     @staticmethod
-    def prepare_gateway_id(gateway_id: str) -> tuple[str, str]:
+    def prepare_gateway_id(gateway_id: str) -> tuple[str, str, int]:
         # Prepend ! to gateway_id if it doesn't have it
         if not gateway_id.startswith("!"):
             gateway_id = f"!{gateway_id}"
@@ -71,7 +70,7 @@ class GatewayManagerEMQX:
         alphabet = string.ascii_letters + string.digits
         return "".join(secrets.choice(alphabet) for i in range(PASSWORD_LENGTH))
 
-    def list_gateways(self) -> Generator[GatewayData, None, None]:
+    def list_gateways(self) -> list[GatewayData]:
         emqx_users = self.emqx.list_users(self.authentication_id)
 
         # Filter for users that match only our regex pattern
@@ -125,9 +124,13 @@ class GatewayManagerEMQX:
     def delete_gateway_user(self, gateway_id: str) -> bool:
         try:
             gateway = self.get_gateway(gateway_id)
-            self.emqx.delete_user(self.authentication_id, gateway.user_string)
+            # Drop the rules before the user. The other order leaves the rules behind whenever
+            # the second call fails, and the user is already gone by then so there is nothing
+            # left to look them up by.
             self.emqx.delete_user_authorization_rules_built_in_database(gateway.user_string)
+            self.emqx.delete_user(self.authentication_id, gateway.user_string)
         except Exception:
+            logger.exception(f"Failed to delete gateway user for {gateway_id}")
             return False
 
         return True
@@ -142,9 +145,11 @@ class GatewayManagerEMQX:
 
         raise ValueError("Gateway not found")
 
-    def reset_gateway_password(self, gateway_id: str, discord_user: Union[User, Member]) -> tuple[GatewayData, str]:
-        gateway_id, gateway_id_without_bang, node_id = self.prepare_gateway_id(gateway_id)
-        gateway = GatewayData(node_id=node_id, owner_id=discord_user.id)
+    def reset_gateway_password(self, gateway_id: str) -> tuple[GatewayData, str]:
+        # Resolve the real owner rather than assuming it is the caller. Building the username
+        # from discord_user.id only worked because this is gated on the owner check; an admin
+        # reset would have targeted a user string that does not exist.
+        gateway = self.get_gateway(gateway_id)
 
         try:
             password = self.generate_password()

--- a/bridger/http.py
+++ b/bridger/http.py
@@ -66,11 +66,6 @@ async def get_displaynames_all(request):
     displaynames = await device.get_all_displaynames()
     return web.json_response(displaynames)
 
-    logo_path = os.path.join(os.path.dirname(__file__), "../logo/logo.png")
-    if not os.path.exists(logo_path):
-        return web.Response(status=404, text="Logo not found")
-    return web.FileResponse(logo_path)
-
 
 @routes.get("/health")
 async def health_check(request):

--- a/bridger/influx/interfaces.py
+++ b/bridger/influx/interfaces.py
@@ -116,15 +116,18 @@ class InfluxReader:
     def _extract_first_record(table_list):
         if not table_list:
             return None
+
         try:
             table = table_list[0]
-            if not table.records:
-                return None
-            return table.records[0]
         except Exception as e:
-            extra = {k: locals()[k] for k in ("table_list", "table")}
-            logger.bind(**extra).error(f"Error processing query result: {e}")
+            # Guard only the indexing. The previous version read `table` out of locals() in
+            # the handler, which raised KeyError when the indexing itself was what failed.
+            logger.bind(table_list=repr(table_list)).error(f"Error processing query result: {e}")
             return None
+
+        if not table.records:
+            return None
+        return table.records[0]
 
 
 class InfluxWriter:

--- a/bridger/mesh/handlers/neighborinfo.py
+++ b/bridger/mesh/handlers/neighborinfo.py
@@ -11,24 +11,26 @@ class NeighborInfoHandler(PacketHandler):
     portnum = PortNum.NEIGHBORINFO_APP
 
     def handle(self):
-        neighbors = [
-            {"neighbor_id": neighbor.get("node_id", None), "snr": neighbor.get("snr", None)}
-            for neighbor in self.base_data.get("neighbors", [])
-        ]
+        neighbors = self.base_data.pop("neighbors", None) or []
 
         if not neighbors:
             logger.bind(**self.base_data).debug("No neighbors found in payload")
             return None
 
         neighbor_points = []
-        self.base_data.pop("neighbors")
 
         for neighbor in neighbors:
-            self.base_data["neighbor_id"] = neighbor.get("neighbor_id")
+            # A fresh copy per neighbor. Mutating one shared dict let each neighbor inherit
+            # the previous neighbor's snr whenever its own was missing.
+            point_data = dict(self.base_data)
+            point_data["neighbor_id"] = neighbor.get("node_id")
 
-            if neighbor.get("snr"):
-                self.base_data["snr"] = neighbor.get("snr")
+            snr = neighbor.get("snr")
+            if snr is not None:
+                # Explicitly not a truthiness check: proto3 omits snr when it is 0.0, and 0 dB
+                # is a real reading, not a missing one.
+                point_data["snr"] = snr
 
-            neighbor_points.append(NeighborInfoPacket(**self.base_data))
+            neighbor_points.append(NeighborInfoPacket(**point_data))
 
         return neighbor_points

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,3 +13,23 @@ def patch_mqtt_topic(monkeypatch):
     for module_name, module in sys.modules.items():
         if module_name.startswith("bridger.") and hasattr(module, "MQTT_TOPIC"):
             monkeypatch.setattr(f"{module_name}.MQTT_TOPIC", test_topic)
+
+
+@pytest.fixture(autouse=True)
+def restore_handler_map():
+    """Undo handler registrations made during a test.
+
+    HANDLER_MAP is a module-level defaultdict that the @handler decorator appends to, so a
+    test that registers a handler leaks it into every test that runs afterwards.
+    """
+    from bridger.mesh.handler_registry import HANDLER_MAP
+
+    # The values are shared list objects that handler() mutates in place, so each one has to
+    # be copied rather than just the outer mapping.
+    saved = {message_type: list(handlers) for message_type, handlers in HANDLER_MAP.items()}
+
+    yield HANDLER_MAP
+
+    # Mutate in place rather than rebinding: bridger.mesh imported this object by reference.
+    HANDLER_MAP.clear()
+    HANDLER_MAP.update(saved)

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,0 +1,57 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bridger.bot import BridgerBot, create_bot, get_owner_id, main
+
+
+class TestGetOwnerId:
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("123", 123),
+            ("  123  ", 123),
+            ("", None),
+            ("   ", None),
+            ("abc", None),
+            ("12.5", None),
+        ],
+    )
+    def test_parsing(self, monkeypatch, raw, expected):
+        monkeypatch.setenv("DISCORD_BOT_OWNER_ID", raw)
+        assert get_owner_id() == expected
+
+    def test_unset(self, monkeypatch):
+        # An empty value raises ValueError rather than TypeError, which the old handler missed.
+        monkeypatch.delenv("DISCORD_BOT_OWNER_ID", raising=False)
+        assert get_owner_id() is None
+
+
+class TestCreateBot:
+    def test_registers_extensions_and_command(self, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_OWNER_ID", "42")
+        bot = create_bot()
+
+        assert isinstance(bot, BridgerBot)
+        assert bot.owner_id == 42
+        assert bot.initial_extensions == ["bridger.cogs.mqtt", "bridger.cogs.testmsg"]
+        assert bot.get_command("sync-commands") is not None
+
+    def test_builds_without_an_owner_id(self, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_OWNER_ID", "")
+        assert create_bot().owner_id is None
+
+
+class TestMain:
+    def test_returns_error_without_a_token(self, monkeypatch):
+        monkeypatch.delenv("DISCORD_BOT_TOKEN", raising=False)
+        assert main() == 1
+
+    def test_runs_the_bot_with_a_token(self, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "token")
+        with patch("bridger.bot.create_bot") as create:
+            bot = MagicMock()
+            create.return_value = bot
+
+            assert main() == 0
+            bot.run.assert_called_once_with("token")

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -122,7 +122,7 @@ def test_get_gateway(gateway_manager):
 # Test reset_gateway_password
 def test_reset_gateway_password(gateway_manager, emqx_mock):
     emqx_mock.update_user_password.return_value = None
-    gateway, password = gateway_manager.reset_gateway_password("1a2b3c4d", mock_discord_user)
+    gateway, password = gateway_manager.reset_gateway_password("1a2b3c4d")
 
     assert isinstance(gateway, GatewayData)
     assert gateway.owner_id == mock_discord_user.id
@@ -281,3 +281,23 @@ def test_update_gateway_user_rules_emqx_error(gateway_manager, emqx_mock):
 
     # Verify that create was not called due to the exception
     emqx_mock.create_user_authorization_rules_built_in_database.assert_not_called()
+
+
+def test_reset_gateway_password_uses_real_owner_not_caller(gateway_manager, emqx_mock):
+    # The username is built from the gateway's registered owner. Deriving it from the caller
+    # meant an admin reset would target a user string that does not exist in EMQX.
+    emqx_mock.update_user_password.return_value = None
+
+    gateway, _ = gateway_manager.reset_gateway_password("1a2b3c4d")
+
+    assert gateway.owner_id == 1234567890
+    assert gateway.user_string == "1234567890-1a2b3c4d"
+
+
+def test_delete_gateway_user_removes_rules_before_user(gateway_manager, emqx_mock):
+    calls = []
+    emqx_mock.delete_user.side_effect = lambda *a, **kw: calls.append("user")
+    emqx_mock.delete_user_authorization_rules_built_in_database.side_effect = lambda *a, **kw: calls.append("rules")
+
+    assert gateway_manager.delete_gateway_user("1a2b3c4d") is True
+    assert calls == ["rules", "user"]

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -67,3 +67,43 @@ def test_neighbor_info_handler_generates_points():
     assert len(result) == 2
     assert result[0].neighbor_id == 111
     assert result[1].neighbor_id == 222
+
+
+def _neighbor_base_data(neighbors):
+    return {
+        "_from": 123,
+        "to": 456,
+        "packet_id": 789,
+        "rx_time": 1600000000,
+        "rx_snr": 12.5,
+        "rx_rssi": -30,
+        "hop_limit": 3,
+        "hop_start": 0,
+        "channel_id": "test",
+        "gateway_id": "!abc123",
+        "node_id": 123,
+        "last_sent_by_id": 999,
+        "neighbors": neighbors,
+    }
+
+
+def test_neighbor_info_handler_does_not_carry_over_snr():
+    # A neighbor with no snr of its own used to inherit the previous neighbor's. proto3 omits
+    # snr when it is 0.0, so a real 0 dB reading hit the same bug.
+    base_data = _neighbor_base_data(
+        [
+            {"node_id": 111, "snr": 6.0},
+            {"node_id": 222},
+            {"node_id": 333, "snr": 0.0},
+        ]
+    )
+
+    result = NeighborInfoHandler(packet=MagicMock(), payload_dict={}, base_data=base_data).handle()
+
+    assert [(p.neighbor_id, p.snr) for p in result] == [(111, 6.0), (222, None), (333, 0.0)]
+
+
+def test_neighbor_info_handler_returns_none_without_neighbors():
+    base_data = _neighbor_base_data([])
+
+    assert NeighborInfoHandler(packet=MagicMock(), payload_dict={}, base_data=base_data).handle() is None

--- a/tests/test_testmsg.py
+++ b/tests/test_testmsg.py
@@ -204,3 +204,57 @@ class TestFormatNodeName:
         node_info = {"short_name": None, "long_name": None}
         result = TestMsg.format_node_name(123456789, node_info)
         assert result == "**123456789**"
+
+
+def _embed_envelope(gateway_id, *, rx_time=1600000000, hop_start=3, hop_limit=2):
+    envelope = MagicMock()
+    envelope.gateway_id = gateway_id
+    envelope.packet.rx_snr = 6.25
+    envelope.packet.rx_rssi = -95
+    envelope.packet.rx_time = rx_time
+    envelope.packet.hop_start = hop_start
+    envelope.packet.hop_limit = hop_limit
+    return envelope
+
+
+class TestCreateEmbed:
+    def test_uses_node_info_and_derives_colour_from_gateway(self, testmsg_cog, mock_influx_reader):
+        mock_influx_reader.get_node_info.return_value = {"short_name": "ABCD", "long_name": "A Node"}
+
+        embed = testmsg_cog.create_embed(_embed_envelope("!1a2b3c4d"))
+
+        assert embed.color.value == 0x2B3C4D
+        assert "**ABCD** - A Node" in embed.description
+        mock_influx_reader.get_node_info.assert_called_once_with(0x1A2B3C4D)
+
+    def test_unparseable_gateway_id_does_not_raise(self, testmsg_cog, mock_influx_reader):
+        # Previously this raised twice: once on int(gateway[-6:], 16) before the try block,
+        # and again on the fallback, which retried the parse with the "!" still attached.
+        embed = testmsg_cog.create_embed(_embed_envelope("!notahexvalue"))
+
+        assert embed.color.value == 0x5865F2
+        assert "notahexvalue" in embed.description
+        mock_influx_reader.get_node_info.assert_not_called()
+
+    def test_empty_gateway_id_does_not_raise(self, testmsg_cog):
+        embed = testmsg_cog.create_embed(_embed_envelope(""))
+
+        assert embed.color.value == 0x5865F2
+        assert "unknown" in embed.description
+
+    def test_influx_failure_still_renders_embed(self, testmsg_cog, mock_influx_reader):
+        mock_influx_reader.get_node_info.side_effect = RuntimeError("influx down")
+
+        embed = testmsg_cog.create_embed(_embed_envelope("!1a2b3c4d"))
+
+        assert embed.color.value == 0x2B3C4D
+        assert "**439041101**" in embed.description  # falls back to the bare node id
+
+    def test_hop_fields(self, testmsg_cog, mock_influx_reader):
+        mock_influx_reader.get_node_info.return_value = None
+
+        direct = testmsg_cog.create_embed(_embed_envelope("!1a2b3c4d", hop_start=3, hop_limit=3))
+        hopped = testmsg_cog.create_embed(_embed_envelope("!1a2b3c4d", hop_start=3, hop_limit=1))
+
+        assert [f.value for f in direct.fields if f.name == "Hops"] == ["Direct/3"]
+        assert [f.value for f in hopped.fields if f.name == "Hops"] == ["2/3"]


### PR DESCRIPTION
Six independent bugs, none of which change the InfluxDB schema or write volume.

Neighbor SNR carried over between neighbors. NeighborInfoHandler mutated one
shared dict across the loop and only assigned snr when it was truthy, so a
neighbor reporting no SNR inherited the previous neighbor's value -- and
because proto3 omits snr when it is 0.0, a real 0 dB reading did too. Verified:
neighbors [(100, 6.0), (200, absent), (300, 0.0)] wrote 6.0 for all three.
Now a fresh dict per neighbor and an `is not None` check. Note this only fixes
new writes; historical rows keep the bad values, so expect a discontinuity in
the graph.json edge panel at deploy.

_extract_first_record raised out of its own error handler. It read `table` from
locals() while reporting the failure, but the failure it was guarding was the
indexing that binds `table` -- so it raised KeyError: 'table' instead of
returning None. Only the indexing is guarded now.

create_embed could kill the MQTT loop. int(gateway[-6:], 16) ran before the try
block entirely, and the fallback retried the parse with the "!" still attached,
so a non-hex gateway id raised twice and the second one was uncaught inside the
async for. Parses once now, falls back to a default colour, and isolates the
InfluxDB lookup so a transient query failure degrades the embed rather than
dropping the message.

reset_gateway_password targeted the wrong EMQX user. It built the username from
the caller's Discord id rather than the gateway's registered owner, which only
worked because the command is gated on the owner check. Resolves via
get_gateway now, and the discord_user parameter is gone since nothing uses it.

delete_gateway_user deleted the auth user before its ACL rules, orphaning the
rules whenever the second call failed. Reversed, and the swallowed exception is
logged.

bot.py crashed on its own documented default. .env.default ships
DISCORD_BOT_OWNER_ID="", and int("") raises ValueError, which the except
TypeError did not catch. Also moves bot.run() behind a __main__ guard so the
module is importable and testable; python -m bridger.bot is unaffected.

Adds an autouse fixture restoring HANDLER_MAP between tests. test_handler.py
registers a DummyHandler into the global registry and never removed it, so
every subsequent test ran with a bogus handler attached to TEXT_MESSAGE_APP.
Confirmed by probe: the pollution is observable without the fixture and gone
with it.

Also removes the unreachable logo block in http.py, corrects two wrong return
annotations and the gps_time type, and fixes the crypto comment -- the default
key is 16 bytes (AES-128), not 32.

207 tests pass, up from 187.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Part of stack #267, created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a>. Review and merge bottom-up.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live MQTT ingest, EMQX credential deletion order, and neighbor telemetry accuracy (historical bad SNR rows remain); bot and gateway fixes are mostly startup/ops correctness with limited blast radius.
> 
> **Overview**
> Fixes several independent correctness bugs across MQTT ingest, Discord bot startup, EMQX gateway lifecycle, and test isolation—without changing Influx write volume or schema (aside from correcting `PositionPoint.gps_time` typing).
> 
> **Ingest / telemetry:** `NeighborInfoHandler` now builds a **fresh dict per neighbor** and sets SNR only when `snr is not None`, so missing neighbors no longer inherit the previous SNR and **0 dB** is stored correctly. `InfluxReader._extract_first_record` no longer raises `KeyError` from its own error path when indexing fails.
> 
> **Test message Discord embeds:** `create_embed` parses the gateway ID once, uses a default blurple color and safe labels when parsing or Influx lookup fails, and isolates lookup errors so bad gateway IDs do not abort the MQTT consumer loop.
> 
> **Gateway / EMQX:** `reset_gateway_password` resolves the gateway via `get_gateway` and updates the **registered owner’s** MQTT username (not the caller’s Discord id). `delete_gateway_user` removes **authorization rules before** deleting the user, with exceptions logged.
> 
> **Bot:** `get_owner_id()` accepts unset/blank `DISCORD_BOT_OWNER_ID` (matching `.env.default`); startup moves behind `create_bot()` / `main()` and a `__main__` guard so the module is importable and testable.
> 
> **Hygiene:** Autouse pytest fixture restores `HANDLER_MAP` after tests; removes dead logo code from `http.py`; minor annotation/comment fixes. Expanded tests cover bot env parsing, embed edge cases, neighbor SNR, and gateway delete/reset ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c2f1dea3ea3239b3ac414e2fc6ee6869a2c2840. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->