### PR TITLE
fix: report the actual EMQX failure and roll back partial gateway creation

### DIFF
--- a/bridger/cli.py
+++ b/bridger/cli.py
@@ -3,14 +3,14 @@ import os
 import secrets
 from pathlib import Path
 
-from requests.exceptions import ConnectionError
+from requests.exceptions import ConnectionError, HTTPError
 from rich.console import Console
 from rich.table import Table
 from rich.text import Text
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
 
 from bridger.emqx import EMQXClient
-from bridger.gateway import GatewayError, GatewayManagerEMQX
+from bridger.gateway import GatewayBackendError, GatewayError, GatewayManagerEMQX
 
 console = Console()
 
@@ -21,10 +21,26 @@ EMQX_URL = os.getenv("EMQX_URL")
 emqx = EMQXClient(EMQX_URL, EMQX_API_KEY, EMQX_SECRET_KEY)
 
 
+def _is_retriable(exception: BaseException) -> bool:
+    """Decide whether a create_gateway_user failure is worth another attempt.
+
+    create_gateway_user wraps request failures in GatewayBackendError, so a plain
+    retry_if_exception_type on ConnectionError stopped matching once that wrapping existed.
+    Unwrap one level, and refuse to retry anything EMQX actually answered.
+    """
+    if isinstance(exception, GatewayBackendError):
+        exception = exception.__cause__
+
+    if isinstance(exception, HTTPError):
+        return False
+
+    return isinstance(exception, (ConnectionError, OSError))
+
+
 @retry(
     stop=stop_after_attempt(5),
     wait=wait_exponential(multiplier=1, min=1, max=60),
-    retry=retry_if_exception_type((ConnectionError, OSError)),
+    retry=retry_if_exception(_is_retriable),
     reraise=True,
 )
 def create_user_command(args):
@@ -48,6 +64,11 @@ def create_user_command(args):
 
         console.print(table)
     except GatewayError as e:
+        # Let tenacity see the failures worth another attempt. Catching every GatewayError here
+        # would swallow them before the decorator ever runs.
+        if _is_retriable(e):
+            raise
+
         console.print(f"Error creating gateway user: {e}", style="bold red")
 
 

--- a/bridger/cogs/mqtt.py
+++ b/bridger/cogs/mqtt.py
@@ -9,7 +9,13 @@ from discord.ext import commands
 from discord.utils import get
 
 from bridger.dataclasses import AnnotationPoint
-from bridger.gateway import GatewayError, GatewayManagerEMQX, emqx
+from bridger.gateway import (
+    GatewayAlreadyExistsError,
+    GatewayError,
+    GatewayManagerEMQX,
+    GatewayValidationError,
+    emqx,
+)
 from bridger.influx.interfaces import InfluxReader, InfluxWriter
 from bridger.log import logger
 
@@ -216,6 +222,19 @@ class MQTTCog(commands.GroupCog, name="bridger-mqtt"):
         self.gateway_manager = gateway_manager
         self.influx_reader = influx_reader
 
+    @staticmethod
+    def _describe_gateway_error(error: GatewayError) -> str:
+        node_id = error.gateway.node_hex_id_without_bang
+
+        if isinstance(error, GatewayAlreadyExistsError):
+            return f"Gateway already exists: {node_id}"
+
+        if isinstance(error, GatewayValidationError):
+            return f"Invalid gateway request for {node_id}: {error}"
+
+        status = f" (HTTP {error.status_code})" if error.status_code else ""
+        return f"Gateway backend error for {node_id}{status}: {error}"
+
     async def cog_app_command_error(self, interaction: Interaction, error: app_commands.AppCommandError):
         # Log the type of error and error message
         logger.debug(f"App command error: {type(error)}: {error}")
@@ -223,7 +242,7 @@ class MQTTCog(commands.GroupCog, name="bridger-mqtt"):
         if isinstance(error, app_commands.errors.CommandInvokeError):
             if isinstance(error.original, GatewayError):
                 await interaction.response.send_message(
-                    f"Gateway already exists: {error.original.gateway.node_hex_id_without_bang}",
+                    self._describe_gateway_error(error.original),
                     ephemeral=True,
                     delete_after=self.delete_after,
                 )

--- a/bridger/cogs/mqtt.py
+++ b/bridger/cogs/mqtt.py
@@ -230,10 +230,13 @@ class MQTTCog(commands.GroupCog, name="bridger-mqtt"):
             return f"Gateway already exists: {node_id}"
 
         if isinstance(error, GatewayValidationError):
-            return f"Invalid gateway request for {node_id}: {error}"
+            return f"Invalid gateway request for {node_id}. Check the node ID and try again."
 
+        # Deliberately no exception text here: the string requests builds for an HTTPError
+        # carries the EMQX URL and API path, and this message goes to a Discord user. The
+        # detail is logged in cog_app_command_error instead.
         status = f" (HTTP {error.status_code})" if error.status_code else ""
-        return f"Gateway backend error for {node_id}{status}: {error}"
+        return f"Gateway backend error for {node_id}{status}. Please try again later or contact an admin."
 
     async def cog_app_command_error(self, interaction: Interaction, error: app_commands.AppCommandError):
         # Log the type of error and error message
@@ -241,12 +244,16 @@ class MQTTCog(commands.GroupCog, name="bridger-mqtt"):
 
         if isinstance(error, app_commands.errors.CommandInvokeError):
             if isinstance(error.original, GatewayError):
+                logger.opt(exception=error.original).warning(
+                    f"Gateway command failed for node {error.original.gateway.node_hex_id_without_bang}"
+                )
                 await interaction.response.send_message(
                     self._describe_gateway_error(error.original),
                     ephemeral=True,
                     delete_after=self.delete_after,
                 )
             else:
+                logger.opt(exception=error.original).warning("Command invoke error")
                 await interaction.response.send_message(
                     f"Command invoke error: {error.original}", ephemeral=True, delete_after=self.delete_after
                 )

--- a/bridger/gateway.py
+++ b/bridger/gateway.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import Optional, Union
 
 from discord import Member, User
-from requests import HTTPError
+from requests import HTTPError, RequestException
 
 from bridger.config import MQTT_TOPIC
 from bridger.dataclasses import NodeMixin
@@ -143,6 +143,11 @@ class GatewayManagerEMQX:
             self.emqx.create_user(self.authentication_id, gateway.user_string, password)
         except HTTPError as e:
             raise self._map_http_error(e, gateway) from e
+        except RequestException as e:
+            # Timeouts and connection resets never reach _map_http_error because they carry no
+            # response. Without this they escape the GatewayError hierarchy entirely and the
+            # caller reports them as an unhandled command error.
+            raise GatewayBackendError(f"Could not reach EMQX: {e}", gateway) from e
 
         # Roll the user back if the rules do not land. Otherwise the account exists with no
         # ACL rules, the caller never receives the password, and every retry from here on

--- a/bridger/gateway.py
+++ b/bridger/gateway.py
@@ -3,7 +3,7 @@ import re
 import secrets
 import string
 from dataclasses import dataclass
-from typing import Union
+from typing import Optional, Union
 
 from discord import Member, User
 from requests import HTTPError
@@ -32,9 +32,22 @@ class GatewayData(NodeMixin):
 
 
 class GatewayError(Exception):
-    def __init__(self, message: str, gateway: GatewayData):
+    def __init__(self, message: str, gateway: GatewayData, *, status_code: Optional[int] = None):
         super().__init__(message)
         self.gateway = gateway
+        self.status_code = status_code
+
+
+class GatewayAlreadyExistsError(GatewayError):
+    """The gateway is already registered in EMQX."""
+
+
+class GatewayValidationError(GatewayError):
+    """EMQX rejected the request as malformed."""
+
+
+class GatewayBackendError(GatewayError):
+    """EMQX failed for a reason that is not the caller's fault."""
 
 
 class GatewayManagerEMQX:
@@ -92,6 +105,33 @@ class GatewayManagerEMQX:
         mqtt_rules = [{"action": "all", "topic": f"{topic_prefix}/+/{gateway_id}", "permission": "allow"}]
         return {"rules": mqtt_rules, "username": username}
 
+    @staticmethod
+    def _map_http_error(error: HTTPError, gateway: GatewayData) -> GatewayError:
+        """Turn an EMQX HTTPError into the specific GatewayError it represents.
+
+        Everything that was not a 400 used to be reported as "gateway already exists", so an
+        expired API key or a broker outage told the user their gateway was registered.
+        """
+        response = getattr(error, "response", None)
+        status_code = getattr(response, "status_code", None)
+        code = None
+
+        if response is not None:
+            try:
+                body = response.json()
+            except Exception:
+                body = None
+            # A MagicMock response returns a truthy mock from .get(), so insist on a real dict.
+            code = body.get("code") if isinstance(body, dict) else None
+
+        if status_code == 409 or (status_code == 400 and code == "ALREADY_EXISTS"):
+            return GatewayAlreadyExistsError(f"Gateway already exists: {error}", gateway, status_code=status_code)
+
+        if status_code == 400:
+            return GatewayValidationError(f"Error creating gateway: {error}", gateway, status_code=status_code)
+
+        return GatewayBackendError(f"Error talking to EMQX: {error}", gateway, status_code=status_code)
+
     def create_gateway_user(self, gateway_id: str, discord_user: Union[User, Member]) -> tuple[GatewayData, str]:
         gateway_id, gateway_id_without_bang, node_id = self.prepare_gateway_id(gateway_id)
         password = self.generate_password()
@@ -101,12 +141,24 @@ class GatewayManagerEMQX:
 
         try:
             self.emqx.create_user(self.authentication_id, gateway.user_string, password)
-            self.emqx.create_user_authorization_rules_built_in_database(gateway.user_string, rules)
         except HTTPError as e:
-            if e.response.status_code == 400:
-                raise GatewayError(f"Error creating gateway: {e}", gateway) from e
-            else:
-                raise GatewayError(f"Gateway already exists: {e}", gateway) from e
+            raise self._map_http_error(e, gateway) from e
+
+        # Roll the user back if the rules do not land. Otherwise the account exists with no
+        # ACL rules, the caller never receives the password, and every retry from here on
+        # reports "already exists".
+        try:
+            self.emqx.create_user_authorization_rules_built_in_database(gateway.user_string, rules)
+        except Exception as e:
+            try:
+                self.emqx.delete_user(self.authentication_id, gateway.user_string)
+                logger.warning(f"Rolled back EMQX user {gateway.user_string} after its rules failed to apply")
+            except Exception:
+                logger.exception(f"Orphaned EMQX user {gateway.user_string}: rules failed and rollback failed too")
+
+            status_code = getattr(getattr(e, "response", None), "status_code", None)
+            raise GatewayBackendError(f"Failed to create authorization rules: {e}", gateway, status_code=status_code) from e
+
         return gateway, password
 
     def update_gateway_user_rules(self, gateway_id: str) -> bool:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,11 +1,11 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-from requests.exceptions import ConnectionError
+from requests.exceptions import ConnectionError, HTTPError
 from tenacity import wait_none
 
 from bridger.cli import create_user_command, delete_user_command, generate_apikey_command, list_users_command, main
-from bridger.gateway import GatewayError
+from bridger.gateway import GatewayBackendError, GatewayError
 
 
 @pytest.fixture(autouse=True)
@@ -68,6 +68,45 @@ class TestCreateUserCommand:
         create_user_command(args)
 
         assert mock_manager.create_gateway_user.call_count == 3
+
+    @patch("bridger.cli.GatewayManagerEMQX")
+    @patch("bridger.cli.console")
+    def test_create_user_retries_wrapped_connection_error(self, mock_console, mock_manager_class):
+        # create_gateway_user wraps connection failures in GatewayBackendError now, so the
+        # retry has to look through the wrapper instead of matching ConnectionError directly.
+        mock_manager = mock_manager_class.return_value
+        wrapped = GatewayBackendError("Could not reach EMQX", MagicMock())
+        wrapped.__cause__ = ConnectionError("Connection failed")
+        mock_manager.create_gateway_user.side_effect = [
+            wrapped,
+            wrapped,
+            (MagicMock(user_string="test_user"), "test_password"),
+        ]
+
+        args = MagicMock()
+        args.gateway_id = "12345678"
+        args.user_id = "987654321"
+
+        create_user_command(args)
+
+        assert mock_manager.create_gateway_user.call_count == 3
+
+    @patch("bridger.cli.GatewayManagerEMQX")
+    @patch("bridger.cli.console")
+    def test_create_user_does_not_retry_answered_http_error(self, mock_console, mock_manager_class):
+        # An expired API key is a 401. Retrying it five times with backoff helps nobody.
+        mock_manager = mock_manager_class.return_value
+        wrapped = GatewayBackendError("Error talking to EMQX", MagicMock(), status_code=401)
+        wrapped.__cause__ = HTTPError("401 Client Error")
+        mock_manager.create_gateway_user.side_effect = wrapped
+
+        args = MagicMock()
+        args.gateway_id = "12345678"
+        args.user_id = "987654321"
+
+        create_user_command(args)
+
+        assert mock_manager.create_gateway_user.call_count == 1
 
     def test_create_user_invalid_user_id_raises(self):
         args = MagicMock()

--- a/tests/test_cogs_mqtt.py
+++ b/tests/test_cogs_mqtt.py
@@ -1,0 +1,50 @@
+from bridger.cogs.mqtt import MQTTCog
+from bridger.gateway import (
+    GatewayAlreadyExistsError,
+    GatewayBackendError,
+    GatewayData,
+    GatewayValidationError,
+)
+
+# The string requests builds for an HTTPError embeds the full request URL.
+EMQX_URL = "http://emqx.internal:18083/api/v5/authentication/password_based:built_in_database/users"
+RAW_HTTP_ERROR = f"500 Server Error: Internal Server Error for url: {EMQX_URL}"
+
+
+def _gateway():
+    return GatewayData(node_id=int("1a2b3c4d", 16), owner_id=1234567890)
+
+
+class TestDescribeGatewayError:
+    def test_already_exists_names_the_node(self):
+        message = MQTTCog._describe_gateway_error(GatewayAlreadyExistsError("whatever", _gateway()))
+
+        assert "1a2b3c4d" in message
+        assert "already exists" in message.lower()
+
+    def test_validation_error_does_not_leak_the_exception_text(self):
+        error = GatewayValidationError(f"Error creating gateway: {RAW_HTTP_ERROR}", _gateway(), status_code=400)
+
+        message = MQTTCog._describe_gateway_error(error)
+
+        assert "1a2b3c4d" in message
+        assert "emqx.internal" not in message
+        assert "/api/v5/" not in message
+
+    def test_backend_error_reports_the_status_but_not_the_url(self):
+        error = GatewayBackendError(f"Error talking to EMQX: {RAW_HTTP_ERROR}", _gateway(), status_code=500)
+
+        message = MQTTCog._describe_gateway_error(error)
+
+        assert "1a2b3c4d" in message
+        assert "HTTP 500" in message
+        assert "emqx.internal" not in message
+        assert "/api/v5/" not in message
+
+    def test_backend_error_without_a_status_omits_it(self):
+        error = GatewayBackendError("Could not reach EMQX: connection refused", _gateway())
+
+        message = MQTTCog._describe_gateway_error(error)
+
+        assert "1a2b3c4d" in message
+        assert "HTTP" not in message

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -4,7 +4,14 @@ import pytest
 from discord import User
 from requests import HTTPError
 
-from bridger.gateway import GatewayData, GatewayError, GatewayManagerEMQX
+from bridger.gateway import (
+    GatewayAlreadyExistsError,
+    GatewayBackendError,
+    GatewayData,
+    GatewayError,
+    GatewayManagerEMQX,
+    GatewayValidationError,
+)
 
 # Sample data for mocking
 state_mock = MagicMock()
@@ -82,11 +89,11 @@ def test_create_gateway_user(gateway_manager, emqx_mock):
     )
 
 
-# Test create_gateway_user when user already exists
-def test_create_gateway_user_already_exists(gateway_manager, emqx_mock):
-    emqx_mock.create_user.side_effect = HTTPError("User already exists", response=MagicMock(status_code=400))
+# Test create_gateway_user when EMQX rejects the request as malformed
+def test_create_gateway_user_validation_error(gateway_manager, emqx_mock):
+    emqx_mock.create_user.side_effect = HTTPError("Bad request", response=MagicMock(status_code=400))
 
-    with pytest.raises(GatewayError):
+    with pytest.raises(GatewayValidationError):
         gateway_manager.create_gateway_user("1a2b3c4d", mock_discord_user)
 
 
@@ -301,3 +308,76 @@ def test_delete_gateway_user_removes_rules_before_user(gateway_manager, emqx_moc
 
     assert gateway_manager.delete_gateway_user("1a2b3c4d") is True
     assert calls == ["rules", "user"]
+
+
+def _http_error(status_code, body=None):
+    response = MagicMock(status_code=status_code)
+    response.json.return_value = body if body is not None else {}
+    return HTTPError(f"HTTP {status_code}", response=response)
+
+
+class TestCreateGatewayUserErrorMapping:
+    def test_conflict_maps_to_already_exists(self, gateway_manager, emqx_mock):
+        emqx_mock.create_user.side_effect = _http_error(409)
+
+        with pytest.raises(GatewayAlreadyExistsError) as e:
+            gateway_manager.create_gateway_user("1a2b3c4d", mock_discord_user)
+
+        assert e.value.status_code == 409
+
+    def test_400_with_already_exists_code_maps_to_already_exists(self, gateway_manager, emqx_mock):
+        emqx_mock.create_user.side_effect = _http_error(400, {"code": "ALREADY_EXISTS"})
+
+        with pytest.raises(GatewayAlreadyExistsError):
+            gateway_manager.create_gateway_user("1a2b3c4d", mock_discord_user)
+
+    def test_server_error_maps_to_backend_error(self, gateway_manager, emqx_mock):
+        # Previously reported to the user as "Gateway already exists".
+        emqx_mock.create_user.side_effect = _http_error(500)
+
+        with pytest.raises(GatewayBackendError) as e:
+            gateway_manager.create_gateway_user("1a2b3c4d", mock_discord_user)
+
+        assert e.value.status_code == 500
+
+    def test_unauthorized_maps_to_backend_error(self, gateway_manager, emqx_mock):
+        emqx_mock.create_user.side_effect = _http_error(401)
+
+        with pytest.raises(GatewayBackendError):
+            gateway_manager.create_gateway_user("1a2b3c4d", mock_discord_user)
+
+    def test_every_subclass_is_still_a_gateway_error(self, gateway_manager, emqx_mock):
+        # bridger.cli and its tests catch the base class.
+        emqx_mock.create_user.side_effect = _http_error(500)
+
+        with pytest.raises(GatewayError):
+            gateway_manager.create_gateway_user("1a2b3c4d", mock_discord_user)
+
+
+class TestCreateGatewayUserRollback:
+    def test_rolls_back_the_user_when_rules_fail(self, gateway_manager, emqx_mock):
+        emqx_mock.create_user.return_value = None
+        emqx_mock.create_user_authorization_rules_built_in_database.side_effect = _http_error(500)
+
+        with pytest.raises(GatewayBackendError):
+            gateway_manager.create_gateway_user("1a2b3c4d", mock_discord_user)
+
+        emqx_mock.delete_user.assert_called_once_with(gateway_manager.authentication_id, "1234567890-1a2b3c4d")
+
+    def test_still_raises_when_the_rollback_also_fails(self, gateway_manager, emqx_mock):
+        emqx_mock.create_user.return_value = None
+        emqx_mock.create_user_authorization_rules_built_in_database.side_effect = _http_error(500)
+        emqx_mock.delete_user.side_effect = RuntimeError("emqx unreachable")
+
+        with pytest.raises(GatewayBackendError):
+            gateway_manager.create_gateway_user("1a2b3c4d", mock_discord_user)
+
+    def test_no_rollback_on_success(self, gateway_manager, emqx_mock):
+        emqx_mock.create_user.return_value = None
+        emqx_mock.create_user_authorization_rules_built_in_database.return_value = None
+
+        gateway, password = gateway_manager.create_gateway_user("1a2b3c4d", mock_discord_user)
+
+        assert gateway.user_string == "1234567890-1a2b3c4d"
+        assert len(password) == 10
+        emqx_mock.delete_user.assert_not_called()

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 from discord import User
 from requests import HTTPError
+from requests.exceptions import ConnectionError, ConnectTimeout, RequestException
 
 from bridger.gateway import (
     GatewayAlreadyExistsError,
@@ -352,6 +353,25 @@ class TestCreateGatewayUserErrorMapping:
 
         with pytest.raises(GatewayError):
             gateway_manager.create_gateway_user("1a2b3c4d", mock_discord_user)
+
+    def test_connection_error_maps_to_backend_error(self, gateway_manager, emqx_mock):
+        # A response-less failure has no status to map, but it still has to stay inside the
+        # GatewayError hierarchy or the Discord cog reports it as an unhandled command error.
+        emqx_mock.create_user.side_effect = ConnectionError("connection refused")
+
+        with pytest.raises(GatewayBackendError) as e:
+            gateway_manager.create_gateway_user("1a2b3c4d", mock_discord_user)
+
+        assert e.value.status_code is None
+        assert isinstance(e.value.__cause__, ConnectionError)
+
+    def test_timeout_maps_to_backend_error(self, gateway_manager, emqx_mock):
+        emqx_mock.create_user.side_effect = ConnectTimeout("timed out")
+
+        with pytest.raises(GatewayBackendError) as e:
+            gateway_manager.create_gateway_user("1a2b3c4d", mock_discord_user)
+
+        assert isinstance(e.value.__cause__, RequestException)
 
 
 class TestCreateGatewayUserRollback:


### PR DESCRIPTION
create_gateway_user mapped every non-400 HTTPError to "gateway already
exists", and the cog's error handler then hardcoded that same string for any
GatewayError. An expired API key, a permissions problem or a broker outage all
told the user their gateway was already registered.

Replace the single GatewayError with a small taxonomy -- GatewayAlreadyExists,
GatewayValidation, GatewayBackend -- carrying the HTTP status, and map on it:
409 (or 400 with an ALREADY_EXISTS body code, which EMQX also emits) is a
conflict, plain 400 is a validation failure, anything else is a backend error.
They subclass GatewayError so bridger.cli's `except GatewayError` is unchanged.
The body parse insists on a real dict, because a MagicMock response returns a
truthy mock from .get() and would otherwise mis-map the existing test.

Also make creation atomic. The user and its ACL rules were created in one try
block, so if the rules call failed the account was left with no rules, the
caller never received the password, and every retry from then on hit "already
exists" -- an unrecoverable state needing manual EMQX surgery. The user is now
rolled back when the rules fail, and an orphan is logged loudly if the rollback
fails too.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Part of stack #267, created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a>. Review and merge bottom-up.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes EMQX gateway provisioning, error classification, and rollback behavior; mis-mapping or failed rollback could still leave orphaned users or confuse operators, though behavior is heavily tested.
> 
> **Overview**
> Fixes misleading **“gateway already exists”** when EMQX actually failed (401, 500, outages) by replacing the single `GatewayError` with **`GatewayAlreadyExistsError`**, **`GatewayValidationError`**, and **`GatewayBackendError`** (with optional HTTP status), mapped from EMQX responses via `_map_http_error` (409 / `ALREADY_EXISTS` vs plain 400 vs everything else). Connection/timeouts are wrapped as backend errors so callers stay on the `GatewayError` hierarchy.
> 
> **`create_gateway_user`** is split so user creation and ACL rules are separate: if rules fail, the EMQX user is **deleted** (with loud logging if rollback fails), avoiding passwordless accounts that block retries.
> 
> The **Discord MQTT cog** uses `_describe_gateway_error` for type-specific, user-safe messages (no EMQX URLs in chat) and logs full failures server-side. **`create-user` CLI** retries only **transient** failures via `_is_retriable` (unwraps `GatewayBackendError`, does not retry answered `HTTPError`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 819e6bc7890eb6372295e445e41bd6aedc818b95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->