### PR TITLE
feat: keep every gateway's reception, and make the write path keep up

### DIFF
--- a/bridger/__main__.py
+++ b/bridger/__main__.py
@@ -1,3 +1,5 @@
+import signal
+
 from paho.mqtt.client import MQTT_ERR_SUCCESS, CallbackAPIVersion
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
@@ -28,8 +30,31 @@ def connect_to_mqtt(influx_client):
     return client
 
 
+def handle_sigterm(signum, frame):
+    """Turn SIGTERM into KeyboardInterrupt so the shutdown path below runs.
+
+    Containers are stopped with SIGTERM, not SIGINT. Without this the process dies where it
+    stands and whatever is sitting in the write batch is lost on every restart.
+    """
+    logger.info("Received SIGTERM, shutting down...")
+    raise KeyboardInterrupt
+
+
+def shutdown(client, influx_client):
+    if client:
+        client.disconnect()
+        client.loop_stop()
+        client.close()  # flushes pending batches
+
+    if influx_client:
+        influx_client.close()
+
+
 if __name__ == "__main__":
     client = None
+    influx_client = None
+
+    signal.signal(signal.SIGTERM, handle_sigterm)
 
     try:
         influx_client = create_influx_client("bridger")
@@ -38,12 +63,8 @@ if __name__ == "__main__":
         client.reconnect_delay_set(min_delay=5, max_delay=120)
         client.loop_forever(retry_first_connection=True)
     except KeyboardInterrupt:
-        logger.info("Received KeyboardInterrupt, shutting down...")
-        if client:
-            client.disconnect()
-            client.loop_stop()
+        logger.info("Shutting down...")
     except Exception as e:
         logger.error(f"Application error: {e}")
-        if client:
-            client.disconnect()
-            client.loop_stop()
+    finally:
+        shutdown(client, influx_client)

--- a/bridger/cogs/testmsg.py
+++ b/bridger/cogs/testmsg.py
@@ -49,7 +49,9 @@ class TestMsg(commands.GroupCog, name="testmsg"):
         self.discord_channel_id = discord_channel_id
         self.discord_channel = None
         self.influx_reader = influx_reader
-        self.deduplicator = PacketDeduplicator(maxlen=100, use_gateway_id=True)
+        # The 1h TTL matches the embed-tracking queue below, so a packet re-heard while its
+        # Discord message is still being updated is still recognised as a duplicate.
+        self.deduplicator = PacketDeduplicator(maxlen=2000, use_gateway_id=True, ttl=3600)
         # Per instance rather than a class attribute, so it does not leak between tests.
         self.node_info_cache = TTLCache(NODE_INFO_CACHE_TTL, name="node-info")
         self._mqtt_task = None
@@ -202,7 +204,14 @@ class TestMsg(commands.GroupCog, name="testmsg"):
             password=MQTT_PASS,
             clean_session=True,
         ) as client:
-            await client.subscribe(full_topic)
+            reason_codes = await client.subscribe(full_topic)
+
+            # A refused subscription otherwise looks exactly like a healthy one: connected,
+            # and then no messages ever arrive.
+            for reason_code in reason_codes or []:
+                if getattr(reason_code, "is_failure", False):
+                    raise aiomqtt.MqttError(f"Broker refused subscription to {full_topic}: {reason_code}")
+
             logger.info(f"Subscribed to {full_topic}")
             await logger.complete()
 

--- a/bridger/deduplication.py
+++ b/bridger/deduplication.py
@@ -1,25 +1,65 @@
-from collections import deque
-
-from meshtastic.protobuf.mqtt_pb2 import ServiceEnvelope
+import time
+from collections import OrderedDict
+from collections.abc import Callable, Hashable
+from typing import Optional
 
 from bridger.log import logger
 
+# Deduplication is really a wall-clock concern: a broker redelivery or a mesh rebroadcast
+# arrives seconds later, regardless of how busy the mesh is. A pure count window couples the
+# horizon to traffic rate instead -- hours on a quiet night, seconds during an event -- so TTL
+# is the primary window and maxlen is only a memory backstop.
+DEFAULT_TTL_SECONDS = 600
+DEFAULT_MAXLEN = 20000
+
 
 class PacketDeduplicator:
-    def __init__(self, maxlen: int = 100, use_gateway_id: bool = False):
-        self.message_queue = deque(maxlen=maxlen)
+    def __init__(
+        self,
+        maxlen: int = DEFAULT_MAXLEN,
+        use_gateway_id: bool = False,
+        ttl: Optional[float] = DEFAULT_TTL_SECONDS,
+        clock: Callable[[], float] = time.monotonic,
+    ):
+        self.maxlen = maxlen
         self.use_gateway_id = use_gateway_id
+        self.ttl = ttl
+        self._clock = clock
+        # Insertion-ordered, so eviction pops from the front; `in` and len() still work, but
+        # membership is O(1) rather than the deque's linear scan.
+        self.message_queue: OrderedDict[Hashable, float] = OrderedDict()
 
-    def is_duplicate(self, service_envelope: ServiceEnvelope) -> bool:
-        packet_id = service_envelope.packet.id
-        gateway_id = service_envelope.gateway_id
+    def _key(self, gateway_id: str, packet_id: int) -> Hashable:
+        return (gateway_id, packet_id) if self.use_gateway_id else packet_id
 
-        if self.use_gateway_id:
-            key = (gateway_id, packet_id)
-        else:
-            key = packet_id
+    @staticmethod
+    def _unpack(service_envelope) -> tuple[str, int]:
+        # Only these two attributes are ever read, which is what keeps this class usable for
+        # a second mesh protocol later.
+        return service_envelope.gateway_id, service_envelope.packet.id
 
-        if key in self.message_queue:
+    def _evict(self) -> None:
+        now = self._clock()
+
+        if self.ttl is not None:
+            while self.message_queue:
+                key, seen_at = next(iter(self.message_queue.items()))
+                if now - seen_at < self.ttl:
+                    break
+                del self.message_queue[key]
+
+        if len(self.message_queue) > self.maxlen:
+            # Hitting this means the window is too small for the deployment: entries are being
+            # forgotten before their TTL, so genuine duplicates can slip through.
+            logger.warning(f"Deduplication window full at {self.maxlen} entries, evicting before TTL")
+
+            while len(self.message_queue) > self.maxlen:
+                self.message_queue.popitem(last=False)
+
+    def is_duplicate_packet(self, gateway_id: str, packet_id: int) -> bool:
+        self._evict()
+
+        if self._key(gateway_id, packet_id) in self.message_queue:
             logger.bind(envelope_id=packet_id).opt(colors=True).debug(
                 f"Packet <yellow>{packet_id}</yellow> from <green>{gateway_id}</green> already in queue"
             )
@@ -27,20 +67,24 @@ class PacketDeduplicator:
 
         return False
 
-    def mark_processed(self, service_envelope: ServiceEnvelope) -> None:
-        packet_id = service_envelope.packet.id
-        gateway_id = service_envelope.gateway_id
+    def mark_processed_packet(self, gateway_id: str, packet_id: int) -> None:
+        key = self._key(gateway_id, packet_id)
+        self.message_queue[key] = self._clock()
+        self.message_queue.move_to_end(key)
+        self._evict()
 
-        if self.use_gateway_id:
-            key = (gateway_id, packet_id)
-        else:
-            key = packet_id
-
-        self.message_queue.append(key)
-
-    def should_process(self, service_envelope: ServiceEnvelope) -> bool:
-        if self.is_duplicate(service_envelope):
+    def should_process_packet(self, gateway_id: str, packet_id: int) -> bool:
+        if self.is_duplicate_packet(gateway_id, packet_id):
             return False
 
-        self.mark_processed(service_envelope)
+        self.mark_processed_packet(gateway_id, packet_id)
         return True
+
+    def is_duplicate(self, service_envelope) -> bool:
+        return self.is_duplicate_packet(*self._unpack(service_envelope))
+
+    def mark_processed(self, service_envelope) -> None:
+        self.mark_processed_packet(*self._unpack(service_envelope))
+
+    def should_process(self, service_envelope) -> bool:
+        return self.should_process_packet(*self._unpack(service_envelope))

--- a/bridger/deduplication.py
+++ b/bridger/deduplication.py
@@ -28,6 +28,7 @@ class PacketDeduplicator:
         # Insertion-ordered, so eviction pops from the front; `in` and len() still work, but
         # membership is O(1) rather than the deque's linear scan.
         self.message_queue: OrderedDict[Hashable, float] = OrderedDict()
+        self._warned_full = False
 
     def _key(self, gateway_id: str, packet_id: int) -> Hashable:
         return (gateway_id, packet_id) if self.use_gateway_id else packet_id
@@ -49,12 +50,21 @@ class PacketDeduplicator:
                 del self.message_queue[key]
 
         if len(self.message_queue) > self.maxlen:
-            # Hitting this means the window is too small for the deployment: entries are being
-            # forgotten before their TTL, so genuine duplicates can slip through.
-            logger.warning(f"Deduplication window full at {self.maxlen} entries, evicting before TTL")
+            if not self._warned_full:
+                # Hitting this means the window is too small for the deployment: entries are
+                # being forgotten before their TTL, so genuine duplicates can slip through.
+                # Latched, because a saturated window is one entry over on every subsequent
+                # packet, and warning per packet would flood the log exactly when the bridge
+                # is busiest.
+                logger.warning(f"Deduplication window full at {self.maxlen} entries, evicting before TTL")
+                self._warned_full = True
 
             while len(self.message_queue) > self.maxlen:
                 self.message_queue.popitem(last=False)
+        elif len(self.message_queue) < self.maxlen:
+            # Dropped back under the cap on its own, so re-arm: a window that drains and then
+            # saturates again is a new occurrence worth reporting.
+            self._warned_full = False
 
     def is_duplicate_packet(self, gateway_id: str, packet_id: int) -> bool:
         self._evict()

--- a/bridger/influx/interfaces.py
+++ b/bridger/influx/interfaces.py
@@ -4,12 +4,26 @@ from textwrap import dedent
 from typing import Optional, Union
 
 from influxdb_client import InfluxDBClient
-from influxdb_client.client.write_api import SYNCHRONOUS
+from influxdb_client.client.write_api import SYNCHRONOUS, WriteOptions
 from influxdb_client.rest import ApiException
 
 from bridger.config import INFLUXDB_V2_BUCKET, INFLUXDB_V2_WRITE_PRECISION
 from bridger.dataclasses import TelemetryPoint
 from bridger.log import logger
+
+# Used by the MQTT bridge only. on_message runs on paho's network thread, so a synchronous
+# HTTP round trip per point would block packet handling -- and with per-gateway deduplication
+# there are several times more points than before. flush_interval bounds worst-case loss on a
+# hard kill to two seconds of packets.
+BRIDGE_WRITE_OPTIONS = WriteOptions(
+    batch_size=200,
+    flush_interval=2_000,
+    jitter_interval=200,
+    retry_interval=5_000,
+    max_retries=5,
+    max_retry_delay=30_000,
+    exponential_base=2,
+)
 
 
 class InfluxReader:
@@ -131,8 +145,38 @@ class InfluxReader:
 
 
 class InfluxWriter:
-    def __init__(self, influx_client: InfluxDBClient):
-        self.write_api = influx_client.write_api(write_options=SYNCHRONOUS)
+    def __init__(self, influx_client: InfluxDBClient, write_options=SYNCHRONOUS):
+        # SYNCHRONOUS by default so callers that depend on write failures raising -- the
+        # annotation command, and the tests -- are unaffected. Only the bridge opts into
+        # batching, where failures surface through the callbacks instead.
+        self.batching = write_options is not SYNCHRONOUS
+        self.write_api = influx_client.write_api(
+            write_options=write_options,
+            error_callback=self._on_write_error,
+            success_callback=self._on_write_success,
+            retry_callback=self._on_write_retry,
+        )
+
+    @staticmethod
+    def _on_write_error(conf, data, exception):
+        # The callback receives serialized line protocol rather than the dataclass, so the
+        # rich context available on the synchronous path is not available here.
+        if isinstance(exception, ApiException) and exception.status == 401:
+            logger.bind(conf=conf).error(f"Credentials for InfluxDB are either not set or incorrect: {exception}")
+        else:
+            logger.bind(conf=conf, data=str(data)[:500]).error(f"Failed to write batch to InfluxDB: {exception}")
+
+    @staticmethod
+    def _on_write_success(conf, data):
+        logger.bind(conf=conf).debug("Wrote batch to InfluxDB")
+
+    @staticmethod
+    def _on_write_retry(conf, data, exception):
+        logger.bind(conf=conf).warning(f"Retrying InfluxDB write: {exception}")
+
+    def close(self):
+        """Flush and dispose. Pending batches are lost if this is skipped."""
+        self.write_api.close()
 
     def write_data(self, record, measurement, fields, tags):
         try:
@@ -152,13 +196,16 @@ class InfluxWriter:
                 write_precision=INFLUXDB_V2_WRITE_PRECISION,
             )
 
+            verb = "Queued" if self.batching else "Wrote"
+
             if isinstance(record, list):
                 logger.bind(**extra).opt(colors=True).info(
-                    f"Wrote {len(record)} {measurement} packets from gateway: <green>{record[0].gateway_id}</green>"
+                    f"{verb} {len(record)} {measurement} packets from gateway: <green>{record[0].gateway_id}</green>"
                 )
             else:
                 logger.bind(**extra).opt(colors=True).info(
-                    f"Wrote {measurement} packet <yellow>{record.packet_id}</yellow> from gateway: <green>{record.gateway_id}</green>"  # noqa: E501
+                    f"{verb} {measurement} packet <yellow>{record.packet_id}</yellow> "
+                    f"from gateway: <green>{record.gateway_id}</green>"
                 )
         except ApiException as e:
             if e.status == 401:

--- a/bridger/mesh/__init__.py
+++ b/bridger/mesh/__init__.py
@@ -1,5 +1,6 @@
 import base64
 from abc import ABC, abstractmethod
+from functools import cached_property
 from typing import Optional, Union
 
 from google.protobuf.json_format import MessageToDict
@@ -54,7 +55,7 @@ class PBPacketProcessor(PacketProcessor):
         if auto_decrypt and self.encrypted:
             self.decrypt()
 
-    @property
+    @cached_property
     def payload_dict(self):
         if isinstance(self.payload, str):
             return {"text": self.payload}
@@ -67,7 +68,7 @@ class PBPacketProcessor(PacketProcessor):
                 use_integers_for_enums=True,
             )
 
-    @property
+    @property  # not cached: reads packet.decoded, which decrypt() replaces
     def portnum(self):
         return self.service_envelope.packet.decoded.portnum
 
@@ -79,7 +80,7 @@ class PBPacketProcessor(PacketProcessor):
     def portnum_friendly_name(self) -> Optional[str]:
         return getattr(self.portnum_protocol, "name", None)
 
-    @property
+    @cached_property
     def payload(self) -> Union[Message, str, bytes]:
         if self.portnum in HANDLER_MAP:
             payload = self.service_envelope.packet.decoded.payload
@@ -122,6 +123,8 @@ class PBPacketProcessor(PacketProcessor):
             "gateway_id": self.service_envelope.gateway_id,
         }
 
+        # payload_dict is cached and shallow-copied here, so handlers must treat nested
+        # payload values as read-only.
         point_data.update(self.payload_dict)
         logger.bind(**point_data).debug(f"Decoded packet: {point_data}")
 

--- a/bridger/mqtt.py
+++ b/bridger/mqtt.py
@@ -8,7 +8,7 @@ from sentry_sdk import add_breadcrumb, set_user
 
 from bridger.config import MQTT_TOPIC
 from bridger.deduplication import PacketDeduplicator
-from bridger.influx.interfaces import InfluxWriter
+from bridger.influx.interfaces import BRIDGE_WRITE_OPTIONS, InfluxWriter
 from bridger.log import logger
 from bridger.mesh import PacketProcessorError, PBPacketProcessor
 from bridger.utils import should_ignore_pki_message
@@ -18,23 +18,47 @@ class BridgerMQTT(Client):
     def __init__(self, influx_client: InfluxDBClient, *args, **kwargs):
         self.influx_client = influx_client  # Before super().__init__ call so it isn't passed to the parent class
         super().__init__(*args, **kwargs)
-        self.deduplicator = PacketDeduplicator(maxlen=100)
+        # Scoped by gateway: rx_snr, rx_rssi and the hop counts are per-gateway measurements,
+        # and gateway_id is a tag, so collapsing on packet id alone threw away every reception
+        # after the first to arrive.
+        self.deduplicator = PacketDeduplicator(use_gateway_id=True)
+        # One writer for the process. A new WriteApi per message meant a fresh batching
+        # pipeline per message, and rebuilding it defeats batching entirely.
+        self.influx_writer = InfluxWriter(influx_client, write_options=BRIDGE_WRITE_OPTIONS)
 
     def on_connect(self, client, userdata, flags, reason_code, properties):
         if reason_code != 0:
             logger.error(f"Connection failed with code: {reason_code}. Attempting to reconnect...")
             return
 
+        # This result is paho's local error code, not the broker's. A broker that denies the
+        # subscription still returns success here, which is why on_subscribe exists below.
         subscription = self.subscribe(MQTT_TOPIC)
         if subscription[0] != 0:
             logger.error(f"Failed to subscribe to topic: {MQTT_TOPIC}")
             return
 
-        logger.info(f"Connected and subscribed to topic: {MQTT_TOPIC}")
+        logger.info(f"Requested subscription to topic: {MQTT_TOPIC}")
+
+    def on_subscribe(self, client, userdata, mid, reason_code_list, properties):
+        """Report the broker's SUBACK.
+
+        Without this a denied subscription looks identical to a healthy one: the bridge logs
+        that it subscribed and then silently receives nothing at all.
+        """
+        for reason_code in reason_code_list:
+            if getattr(reason_code, "is_failure", False):
+                logger.error(f"Broker refused subscription to {MQTT_TOPIC}: {reason_code}. No packets will arrive.")
+            else:
+                logger.info(f"Subscribed to {MQTT_TOPIC} with QoS {reason_code.value}")
 
     def on_disconnect(self, client, userdata, disconnect_flags, reason_code, properties):
         if reason_code == 0:
             logger.info("Disconnected")
+
+    def close(self):
+        """Flush pending writes. Batched points are lost otherwise."""
+        self.influx_writer.close()
 
     def on_message(self, client, userdata, message):
         message_payload = base64.b64encode(message.payload)
@@ -58,14 +82,13 @@ class BridgerMQTT(Client):
 
             packet_id = service_envelope.packet.id
             pb_processor = PBPacketProcessor(service_envelope)
-            influx_writer = InfluxWriter(self.influx_client)
             set_user({"id": getattr(service_envelope.packet, "from")})
 
             data = pb_processor.data
 
             if data:
                 logger.bind(envelope_id=packet_id).debug(f"Trying to write data: {data}")
-                influx_writer.write_point(data)
+                self.influx_writer.write_point(data)
             else:
                 logger.bind(envelope_id=packet_id).debug("No data to write")
 

--- a/tests/test_deduplication.py
+++ b/tests/test_deduplication.py
@@ -281,3 +281,47 @@ class TestProtocolAgnosticApi:
 
         assert dedup.should_process_packet("!gw", 1) is True
         assert dedup.is_duplicate(_envelope("!gw", 1)) is True
+
+
+class TestWindowFullWarning:
+    @staticmethod
+    def _clocked(**kwargs):
+        now = [0.0]
+        dedup = PacketDeduplicator(clock=lambda: now[0], **kwargs)
+        return dedup, now
+
+    @patch("bridger.deduplication.logger")
+    def test_no_warning_while_the_window_has_room(self, mock_logger):
+        dedup, _ = self._clocked(ttl=10**6, maxlen=10)
+
+        for packet_id in range(10):
+            dedup.should_process(_envelope("!gw", packet_id))
+
+        mock_logger.warning.assert_not_called()
+
+    @patch("bridger.deduplication.logger")
+    def test_warns_once_however_long_the_window_stays_full(self, mock_logger):
+        # A saturated window is one entry over the cap on every subsequent packet, so an
+        # unlatched warning fires per packet and floods the log when the bridge is busiest.
+        dedup, _ = self._clocked(ttl=10**6, maxlen=3)
+
+        for packet_id in range(100):
+            dedup.should_process(_envelope("!gw", packet_id))
+
+        assert mock_logger.warning.call_count == 1
+
+    @patch("bridger.deduplication.logger")
+    def test_rearms_once_the_window_drains(self, mock_logger):
+        dedup, now = self._clocked(ttl=60, maxlen=3)
+
+        for packet_id in range(10):
+            dedup.should_process(_envelope("!gw", packet_id))
+
+        assert mock_logger.warning.call_count == 1
+
+        # Everything ages out, so saturating again is a fresh occurrence.
+        now[0] = 1000
+        for packet_id in range(100, 110):
+            dedup.should_process(_envelope("!gw", packet_id))
+
+        assert mock_logger.warning.call_count == 2

--- a/tests/test_deduplication.py
+++ b/tests/test_deduplication.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from bridger.deduplication import PacketDeduplicator
+from bridger.deduplication import DEFAULT_MAXLEN, DEFAULT_TTL_SECONDS, PacketDeduplicator
 
 
 @pytest.fixture
@@ -42,26 +42,27 @@ def service_envelope_different_gateway():
 class TestPacketDeduplicator:
     def test_init_default_maxlen(self):
         deduplicator = PacketDeduplicator()
-        assert deduplicator.message_queue.maxlen == 100
+        assert deduplicator.maxlen == DEFAULT_MAXLEN
+        assert deduplicator.ttl == DEFAULT_TTL_SECONDS
 
     def test_init_custom_maxlen(self):
         deduplicator = PacketDeduplicator(maxlen=50)
-        assert deduplicator.message_queue.maxlen == 50
+        assert deduplicator.maxlen == 50
 
     def test_is_duplicate_empty_queue(self, deduplicator, service_envelope):
         assert not deduplicator.is_duplicate(service_envelope)
 
     def test_is_duplicate_not_in_queue(self, deduplicator, service_envelope):
-        deduplicator.message_queue.append(99999)
+        deduplicator.message_queue[99999] = deduplicator._clock()
         assert not deduplicator.is_duplicate(service_envelope)
 
     def test_is_duplicate_in_queue(self, deduplicator, service_envelope):
-        deduplicator.message_queue.append(12345)
+        deduplicator.message_queue[12345] = deduplicator._clock()
         assert deduplicator.is_duplicate(service_envelope)
 
     @patch("bridger.deduplication.logger")
     def test_is_duplicate_logs_message(self, mock_logger, deduplicator, service_envelope):
-        deduplicator.message_queue.append(12345)
+        deduplicator.message_queue[12345] = deduplicator._clock()
         deduplicator.is_duplicate(service_envelope)
         mock_logger.bind.assert_called_once_with(envelope_id=12345)
 
@@ -96,7 +97,7 @@ class TestPacketDeduplicator:
         assert deduplicator.should_process(service_envelope)
         assert not deduplicator.should_process(service_envelope_different_gateway)
 
-    def test_bounded_deque_behavior(self, deduplicator):
+    def test_bounded_window_behavior(self, deduplicator):
         # Fill queue to capacity (maxlen=3)
         for i in range(3):
             envelope = MagicMock()
@@ -121,7 +122,7 @@ class TestPacketDeduplicator:
         assert 2 in deduplicator.message_queue
         assert 3 in deduplicator.message_queue
 
-    def test_bounded_deque_allows_reprocessing_evicted_packets(self, deduplicator):
+    def test_bounded_window_allows_reprocessing_evicted_packets(self, deduplicator):
         # Fill queue to capacity and beyond
         envelopes = []
         for i in range(5):
@@ -140,18 +141,18 @@ class TestPacketDeduplicator:
 class TestPacketDeduplicatorWithGatewayId:
     def test_init_with_gateway_id(self, deduplicator_with_gateway_id):
         assert deduplicator_with_gateway_id.use_gateway_id is True
-        assert deduplicator_with_gateway_id.message_queue.maxlen == 3
+        assert deduplicator_with_gateway_id.maxlen == 3
 
     def test_mark_processed_adds_to_queue_with_gateway_id(self, deduplicator_with_gateway_id, service_envelope):
         deduplicator_with_gateway_id.mark_processed(service_envelope)
         assert ("!1a2b3c4d", 12345) in deduplicator_with_gateway_id.message_queue
 
     def test_is_duplicate_with_gateway_id_not_in_queue(self, deduplicator_with_gateway_id, service_envelope):
-        deduplicator_with_gateway_id.message_queue.append(("!different", 99999))
+        deduplicator_with_gateway_id.message_queue[("!different", 99999)] = deduplicator_with_gateway_id._clock()
         assert not deduplicator_with_gateway_id.is_duplicate(service_envelope)
 
     def test_is_duplicate_with_gateway_id_in_queue(self, deduplicator_with_gateway_id, service_envelope):
-        deduplicator_with_gateway_id.message_queue.append(("!1a2b3c4d", 12345))
+        deduplicator_with_gateway_id.message_queue[("!1a2b3c4d", 12345)] = deduplicator_with_gateway_id._clock()
         assert deduplicator_with_gateway_id.is_duplicate(service_envelope)
 
     def test_should_process_same_packet_different_gateway_with_gateway_id(
@@ -166,7 +167,7 @@ class TestPacketDeduplicatorWithGatewayId:
         deduplicator_with_gateway_id.mark_processed(service_envelope)
         assert not deduplicator_with_gateway_id.should_process(service_envelope)
 
-    def test_bounded_deque_behavior_with_gateway_id(self, deduplicator_with_gateway_id):
+    def test_bounded_window_behavior_with_gateway_id(self, deduplicator_with_gateway_id):
         # Fill queue to capacity (maxlen=3)
         for i in range(3):
             envelope = MagicMock()
@@ -190,3 +191,93 @@ class TestPacketDeduplicatorWithGatewayId:
         assert ("!test", 1) in deduplicator_with_gateway_id.message_queue
         assert ("!test", 2) in deduplicator_with_gateway_id.message_queue
         assert ("!test", 3) in deduplicator_with_gateway_id.message_queue
+
+
+def _envelope(gateway_id, packet_id):
+    envelope = MagicMock()
+    envelope.gateway_id = gateway_id
+    envelope.packet.id = packet_id
+    return envelope
+
+
+class TestTTLWindow:
+    @staticmethod
+    def _clocked(**kwargs):
+        now = [0.0]
+        dedup = PacketDeduplicator(clock=lambda: now[0], **kwargs)
+        return dedup, now
+
+    def test_entries_expire_and_allow_reprocessing(self):
+        dedup, now = self._clocked(ttl=60)
+        envelope = _envelope("!gw", 1)
+
+        assert dedup.should_process(envelope) is True
+        assert dedup.should_process(envelope) is False
+
+        now[0] = 61
+        assert dedup.should_process(envelope) is True
+
+    def test_entries_survive_within_the_ttl(self):
+        dedup, now = self._clocked(ttl=60)
+        envelope = _envelope("!gw", 1)
+
+        dedup.should_process(envelope)
+        now[0] = 59
+        assert dedup.should_process(envelope) is False
+
+    def test_expiry_is_per_entry(self):
+        dedup, now = self._clocked(ttl=60)
+
+        dedup.should_process(_envelope("!gw", 1))
+        now[0] = 30
+        dedup.should_process(_envelope("!gw", 2))
+        now[0] = 61
+
+        # The first has aged out, the second has not.
+        assert dedup.should_process(_envelope("!gw", 1)) is True
+        assert dedup.should_process(_envelope("!gw", 2)) is False
+
+    def test_ttl_none_disables_expiry(self):
+        dedup, now = self._clocked(ttl=None)
+        envelope = _envelope("!gw", 1)
+
+        dedup.should_process(envelope)
+        now[0] = 10**9
+
+        assert dedup.should_process(envelope) is False
+
+    def test_maxlen_still_caps_the_window(self):
+        dedup, _ = self._clocked(ttl=10**6, maxlen=3)
+
+        for packet_id in range(5):
+            dedup.should_process(_envelope("!gw", packet_id))
+
+        assert len(dedup.message_queue) == 3
+        assert dedup.should_process(_envelope("!gw", 0)) is True  # evicted, so seen as new
+        assert dedup.should_process(_envelope("!gw", 4)) is False
+
+
+class TestGatewayScoping:
+    def test_same_packet_from_two_gateways_is_kept_when_scoped(self):
+        # The bridge relies on this: rx_snr/rx_rssi are per-gateway measurements, so every
+        # gateway's reception of a packet has to be written, not just the first to arrive.
+        dedup = PacketDeduplicator(use_gateway_id=True)
+
+        assert dedup.should_process(_envelope("!gw1", 1)) is True
+        assert dedup.should_process(_envelope("!gw2", 1)) is True
+        assert dedup.should_process(_envelope("!gw1", 1)) is False
+
+    def test_same_packet_from_two_gateways_is_collapsed_when_unscoped(self):
+        dedup = PacketDeduplicator(use_gateway_id=False)
+
+        assert dedup.should_process(_envelope("!gw1", 1)) is True
+        assert dedup.should_process(_envelope("!gw2", 1)) is False
+
+
+class TestProtocolAgnosticApi:
+    def test_packet_level_api_matches_the_envelope_api(self):
+        # The (gateway_id, packet_id) entry point is what a second mesh protocol would use.
+        dedup = PacketDeduplicator(use_gateway_id=True)
+
+        assert dedup.should_process_packet("!gw", 1) is True
+        assert dedup.is_duplicate(_envelope("!gw", 1)) is True

--- a/tests/test_mqtt.py
+++ b/tests/test_mqtt.py
@@ -72,3 +72,73 @@ class TestBridgerMQTT:
             assert (
                 len(mqtt_client.deduplicator.message_queue) == 1
             )  # The second packet should be skipped, queue length should remain 1
+
+
+class TestWriterLifecycle:
+    def test_one_writer_for_the_process(self, influx_client, mqtt_message):
+        # A WriteApi per message rebuilt the batching pipeline every time, which defeats it.
+        client = BridgerMQTT(influx_client, CallbackAPIVersion.VERSION2)
+        client._handle_decode_error = MagicMock()
+
+        with patch.object(ServiceEnvelope, "FromString", return_value=MagicMock(packet=MagicMock(id=1))):
+            client.on_message(client, None, mqtt_message)
+            client.on_message(client, None, mqtt_message)
+
+        assert influx_client.write_api.call_count == 1
+
+    def test_close_flushes_pending_writes(self, influx_client):
+        client = BridgerMQTT(influx_client, CallbackAPIVersion.VERSION2)
+
+        client.close()
+
+        influx_client.write_api.return_value.close.assert_called_once()
+
+
+class TestGatewayScopedDeduplication:
+    def test_the_same_packet_from_two_gateways_is_kept(self, mqtt_client, mqtt_message):
+        # rx_snr/rx_rssi are per-gateway, and gateway_id is a tag, so each gateway's reception
+        # has to be written rather than only the first to arrive.
+        mqtt_client._handle_decode_error = MagicMock()
+
+        first = MagicMock(packet=MagicMock(id=1), gateway_id="!gw1")
+        second = MagicMock(packet=MagicMock(id=1), gateway_id="!gw2")
+
+        with patch.object(ServiceEnvelope, "FromString", side_effect=[first, second]):
+            mqtt_client.on_message(mqtt_client, None, mqtt_message)
+            mqtt_client.on_message(mqtt_client, None, mqtt_message)
+
+        assert len(mqtt_client.deduplicator.message_queue) == 2
+
+    def test_the_same_packet_from_one_gateway_is_dropped(self, mqtt_client, mqtt_message):
+        mqtt_client._handle_decode_error = MagicMock()
+
+        envelope = MagicMock(packet=MagicMock(id=1), gateway_id="!gw1")
+
+        with patch.object(ServiceEnvelope, "FromString", return_value=envelope):
+            mqtt_client.on_message(mqtt_client, None, mqtt_message)
+            mqtt_client.on_message(mqtt_client, None, mqtt_message)
+
+        assert len(mqtt_client.deduplicator.message_queue) == 1
+
+
+class TestSubscribeReporting:
+    def test_a_refused_suback_is_logged_as_an_error(self, mqtt_client):
+        # paho's local return code is success even when the broker denies the subscription,
+        # so without this the bridge reports healthy and silently receives nothing.
+        denied = MagicMock(is_failure=True)
+        denied.__str__ = lambda self: "Not authorized"
+
+        with patch("bridger.mqtt.logger") as log:
+            mqtt_client.on_subscribe(mqtt_client, None, 1, [denied], None)
+
+        assert log.error.called
+        assert "No packets will arrive" in log.error.call_args[0][0]
+
+    def test_a_granted_suback_is_logged_as_info(self, mqtt_client):
+        granted = MagicMock(is_failure=False, value=0)
+
+        with patch("bridger.mqtt.logger") as log:
+            mqtt_client.on_subscribe(mqtt_client, None, 1, [granted], None)
+
+        assert not log.error.called
+        assert log.info.called

--- a/tests/test_testmsg.py
+++ b/tests/test_testmsg.py
@@ -56,7 +56,8 @@ class TestTestMsgCog:
     def test_init_creates_deduplicator(self, testmsg_cog):
         assert hasattr(testmsg_cog, "deduplicator")
         assert isinstance(testmsg_cog.deduplicator, PacketDeduplicator)
-        assert testmsg_cog.deduplicator.message_queue.maxlen == 100
+        assert testmsg_cog.deduplicator.maxlen == 2000
+        assert testmsg_cog.deduplicator.ttl == 3600
 
     def test_deduplicator_processes_unique_message(self, testmsg_cog, mock_service_envelope):
         assert testmsg_cog.deduplicator.should_process(mock_service_envelope)


### PR DESCRIPTION
The bridge deduplicated on packet id alone, so when five gateways uplinked the
same packet only the first was written. But rx_snr, rx_rssi and the hop counts
are per-gateway measurements and gateway_id is already a tag, so four fifths of
the RF data was being discarded -- and /bridger-mqtt is-alive reported a
gateway dead whenever it consistently lost the race to report.

Dedup is now scoped by (gateway_id, packet_id), and the window is primarily a
TTL rather than a count. A count window couples the dedup horizon to traffic
rate -- hours on a quiet night, seconds during an event -- whereas what we are
actually defending against, broker redeliveries and mesh rebroadcasts, happens
on a wall clock. maxlen stays as a memory backstop and warns when it evicts
before the TTL, which is the signal that the window is undersized. The queue is
an OrderedDict now, so membership is O(1) instead of a linear scan, and the
clock is injectable so TTL is testable without sleeping. The key extraction is
also split out behind a (gateway_id, packet_id) entry point, so a second mesh
protocol can reuse this unchanged.

That multiplies write volume by the gateway fan-out, which the write path could
not have absorbed: a fresh WriteApi was constructed per message, and every
write was a synchronous HTTP round trip on paho's network thread. Under load
that thread would have spent most of its time blocked, delaying PINGREQ and
risking broker-side disconnects -- silent packet loss, which is worse than
anything batching costs. There is now one writer for the process, batching with
a 2s flush interval, and failures surface through error callbacks. SYNCHRONOUS
remains the default so the annotation command, which depends on writes raising,
is unaffected. The "Wrote N packets" log says "Queued" on the batching path
rather than claiming a write that has not happened yet.

Because batches are held in memory, shutdown now flushes: SIGTERM is handled
(containers are stopped with SIGTERM, not SIGINT, so the previous code lost the
last batch on every restart) and cleanup moved into a finally block.

Also makes subscription failures loud. Both clients checked only the local
return code, not the broker's SUBACK, so a refused subscription logged
"connected and subscribed" and then received nothing forever.

Finally, payload and payload_dict are cached_property. data() reads payload_dict
three times and each read re-ran FromString; verified the parses per packet drop
from 3 to 1. portnum is deliberately left uncached since it reads packet.decoded,
which decrypt() replaces.

Before deploying: point volume rises by roughly the average gateway fan-out
(3-8x), so check bucket retention and disk headroom, and expect the neighbour
count panel in node.json to step. The rx_snr/rx_rssi panels get more correct.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Part of stack #267, created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a>. Review and merge bottom-up.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core MQTT→Influx ingestion (dedup semantics, ~3–8× write volume, async batching) but adds flush-on-shutdown and broad test coverage.
> 
> **Overview**
> Fixes **RF telemetry loss** when multiple gateways uplink the same packet by deduplicating on **`(gateway_id, packet_id)`** instead of packet id alone, so each gateway’s rx_snr/rx_rssi/hop metrics can be written. **`PacketDeduplicator`** now uses a **TTL-first** window (with `maxlen` as a memory cap), an **`OrderedDict`** for O(1) lookups, optional injectable clock, and a latched warning when the window fills before TTL.
> 
> The MQTT bridge keeps **one shared `InfluxWriter`** with **`BRIDGE_WRITE_OPTIONS`** (2s flush batching) instead of synchronous per-message writes on paho’s network thread; logs say **“Queued”** on the batching path. **Shutdown** maps **SIGTERM → `KeyboardInterrupt`**, runs cleanup in **`finally`**, and **`close()`** flushes pending batches on the MQTT client and Influx client.
> 
> **Subscription failures** are surfaced via **`on_subscribe` / SUBACK** checks (paho + testmsg aiomqtt). **`testmsg`** uses a longer dedup TTL aligned with embed tracking. **`PBPacketProcessor`** caches **`payload` / `payload_dict`** to cut repeated protobuf work per packet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62a5d305f7f30e689f6b6b714b9f1491cb6afe77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->