### PR TITLE
feat: record traceroute results as one point per hop

### DIFF
--- a/bridger/dataclasses.py
+++ b/bridger/dataclasses.py
@@ -137,13 +137,28 @@ class TextMessagePoint(TelemetryPoint):
 
 @dataclass_json(undefined=Undefined.EXCLUDE)
 @dataclass
-class TraceroutePoint(TelemetryPoint):
-    measurement_name = "traceroute"
+class TracerouteHopPoint(TelemetryPoint):
+    """One leg of a traceroute.
 
-    route: Optional[int] = None
-    snr_towards: Optional[int] = None
-    route_back: Optional[int] = None
-    snr_back: Optional[int] = None
+    A new measurement rather than more columns on the old `traceroute` one: the old points
+    carried no route data at all (none of the four RouteDiscovery fields declared an
+    influx_kind, so they were silently dropped), and one row per packet has become one row
+    per hop, so the semantics genuinely changed.
+
+    direction and hop_index have to be tags. Bridger writes no explicit timestamp, so the
+    server assigns ingest time; as fields, every hop of one traceroute would collapse into a
+    single series and timestamp and overwrite each other, leaving exactly one hop. This is the
+    same reason NeighborInfoPacket.neighbor_id and PowerTelemetryPoint.channel are tags.
+    """
+
+    measurement_name = "traceroute_hop"
+
+    direction: str = field(metadata={"influx_kind": "tag"})  # "towards" or "back"
+    hop_index: int = field(metadata={"influx_kind": "tag"})  # 0-based leg within the direction
+    from_node_id: int = field(metadata={"influx_kind": "tag"})  # transmitter of this leg
+    node_id: int = field(metadata={"influx_kind": "tag"})  # receiver, which measured the SNR
+    route_length: Optional[int] = field(default=None, metadata={"influx_kind": "field"})
+    snr: Optional[float] = field(default=None, metadata={"influx_kind": "field"})  # dB, already scaled
 
 
 @dataclass_json(undefined=Undefined.EXCLUDE)

--- a/bridger/mesh/handlers/traceroute.py
+++ b/bridger/mesh/handlers/traceroute.py
@@ -1,8 +1,17 @@
 from meshtastic.protobuf.portnums_pb2 import PortNum
 
-from bridger.dataclasses import TraceroutePoint
+from bridger.dataclasses import TracerouteHopPoint
+from bridger.log import logger
 from bridger.mesh.base import PacketHandler
 from bridger.mesh.handler_registry import handler
+
+# RouteDiscovery carries SNR as an int scaled by 4, with -128 meaning "unknown".
+SNR_SCALE = 4
+UNKNOWN_SNR = -128
+
+# Stripped from base_data before constructing a point: these are the raw repeated fields
+# the hops are derived from, not values on any single hop.
+TRACEROUTE_PAYLOAD_KEYS = {"route", "snr_towards", "route_back", "snr_back"}
 
 
 @handler
@@ -10,5 +19,58 @@ class TracerouteHandler(PacketHandler):
     portnum = PortNum.TRACEROUTE_APP
 
     def handle(self):
-        # TODO: The fields could be lists so we need to send each list item as a separate point
-        return TraceroutePoint(**self.base_data)
+        # For a traceroute response, packet.to is the node that asked and packet.from is the
+        # node that answered, so the forward path runs to -> route... -> from.
+        origin = self.base_data.get("to")
+        responder = self.base_data.get("_from")
+
+        points = self._legs(
+            "towards",
+            [origin, *self.payload_dict.get("route", []), responder],
+            self.payload_dict.get("snr_towards", []),
+        )
+        points += self._legs(
+            "back",
+            [responder, *self.payload_dict.get("route_back", []), origin],
+            self.payload_dict.get("snr_back", []),
+        )
+
+        return points or None
+
+    def _legs(self, direction, nodes, snrs):
+        # A traceroute request carries an empty RouteDiscovery, and a direction with no SNR at
+        # all tells us nothing the packet's own rx_snr does not. Skip both rather than writing
+        # rows that only restate the adjacency.
+        if not snrs:
+            return []
+
+        expected = len(nodes) - 1
+
+        if len(snrs) != expected:
+            logger.bind(direction=direction, nodes=nodes, snrs=list(snrs)).debug(
+                "Traceroute SNR list length does not match the route; emitting hops without SNR"
+            )
+            snrs = []
+
+        points = []
+
+        for index in range(expected):
+            point_data = {k: v for k, v in self.base_data.items() if k not in TRACEROUTE_PAYLOAD_KEYS}
+            point_data.update(
+                direction=direction,
+                hop_index=index,
+                from_node_id=nodes[index],
+                node_id=nodes[index + 1],
+                route_length=expected,
+                snr=self._snr(snrs, index),
+            )
+            points.append(TracerouteHopPoint(**point_data))
+
+        return points
+
+    @staticmethod
+    def _snr(snrs, index):
+        if index >= len(snrs) or snrs[index] == UNKNOWN_SNR:
+            return None
+
+        return snrs[index] / SNR_SCALE

--- a/tests/handlers/test_handler_traceroute.py
+++ b/tests/handlers/test_handler_traceroute.py
@@ -1,0 +1,144 @@
+import pytest
+
+from bridger.dataclasses import TracerouteHopPoint
+from bridger.influx.interfaces import InfluxWriter
+from bridger.mesh.handlers.traceroute import TracerouteHandler
+
+REQUESTER = 0xBBBB
+RESPONDER = 0xAAAA
+
+
+class TestTracerouteHandler:
+    def setup_method(self):
+        self.base_data = {
+            "_from": RESPONDER,
+            "to": REQUESTER,
+            "packet_id": 789,
+            "rx_time": 1600000000,
+            "rx_snr": 12.5,
+            "rx_rssi": -30,
+            "hop_limit": 3,
+            "hop_start": 3,
+            "channel_id": "LongFast",
+            "gateway_id": "!abc123",
+        }
+
+    def handle(self, payload):
+        return TracerouteHandler(packet=None, payload_dict=payload, base_data={**self.base_data, **payload}).handle()
+
+    def test_forward_path_is_one_point_per_hop(self):
+        # Forward path runs requester -> route... -> responder, and each SNR is measured by
+        # the receiver of that leg.
+        points = self.handle({"route": [0x1111, 0x2222], "snr_towards": [20, 12, 8]})
+
+        assert [(p.hop_index, p.from_node_id, p.node_id, p.snr) for p in points] == [
+            (0, REQUESTER, 0x1111, 5.0),
+            (1, 0x1111, 0x2222, 3.0),
+            (2, 0x2222, RESPONDER, 2.0),
+        ]
+        assert {p.direction for p in points} == {"towards"}
+        assert {p.route_length for p in points} == {3}
+
+    def test_direct_connection_is_a_single_hop(self):
+        points = self.handle({"snr_towards": [24]})
+
+        assert len(points) == 1
+        assert (points[0].from_node_id, points[0].node_id, points[0].snr) == (REQUESTER, RESPONDER, 6.0)
+
+    def test_round_trip_emits_both_directions(self):
+        points = self.handle(
+            {
+                "route": [0x1111],
+                "snr_towards": [20, 12],
+                "route_back": [0x1111],
+                "snr_back": [16, 8],
+            }
+        )
+
+        towards = [p for p in points if p.direction == "towards"]
+        back = [p for p in points if p.direction == "back"]
+
+        assert [(p.from_node_id, p.node_id) for p in towards] == [(REQUESTER, 0x1111), (0x1111, RESPONDER)]
+        assert [(p.from_node_id, p.node_id) for p in back] == [(RESPONDER, 0x1111), (0x1111, REQUESTER)]
+
+    def test_unknown_snr_sentinel_becomes_none(self):
+        # -128 means "unknown", not -32 dB.
+        points = self.handle({"route": [0x1111], "snr_towards": [20, -128]})
+
+        assert [p.snr for p in points] == [5.0, None]
+
+    def test_zero_snr_is_preserved(self):
+        points = self.handle({"snr_towards": [0]})
+
+        assert points[0].snr == 0.0
+
+    def test_a_traceroute_request_writes_nothing(self):
+        # A request carries an empty RouteDiscovery, so MessageToDict yields {}.
+        assert self.handle({}) is None
+
+    def test_a_direction_without_snr_is_skipped(self):
+        points = self.handle({"route": [0x1111], "snr_towards": [20, 12], "route_back": [0x1111]})
+
+        assert {p.direction for p in points} == {"towards"}
+
+    def test_mismatched_snr_length_still_emits_hops(self):
+        points = self.handle({"route": [0x1111, 0x2222], "snr_towards": [20]})
+
+        assert len(points) == 3
+        assert [p.snr for p in points] == [None, None, None]
+
+    def test_raw_route_fields_do_not_leak_onto_the_point(self):
+        points = self.handle({"route": [0x1111], "snr_towards": [20, 12]})
+
+        assert not hasattr(points[0], "route")
+        assert not hasattr(points[0], "snr_towards")
+
+
+class TestTracerouteInfluxMapping:
+    def test_tags_and_fields(self):
+        tags, fields = InfluxWriter.extract_keys(TracerouteHopPoint)
+
+        # hop_index and direction must be tags: with no explicit timestamp the server assigns
+        # ingest time, so as fields every hop would collapse into one series and overwrite.
+        for tag in ("direction", "hop_index", "from_node_id", "node_id"):
+            assert tag in tags, f"{tag} must be a tag"
+
+        for field_name in ("snr", "route_length"):
+            assert field_name in fields, f"{field_name} must be a field"
+
+
+def _telemetry_point_subclasses():
+    from bridger.dataclasses import TelemetryPoint
+
+    def walk(cls):
+        for sub in cls.__subclasses__():
+            yield sub
+            yield from walk(sub)
+
+    return sorted(set(walk(TelemetryPoint)), key=lambda c: c.__name__)
+
+
+# Fields deliberately never written to InfluxDB. Listing them explicitly means a new omission
+# has to be a conscious decision rather than an oversight.
+INTENTIONALLY_UNWRITTEN = {
+    ("TextMessagePoint", "text"),  # we record that a message happened, never its contents
+    ("NodeInfoPoint", "id"),  # the hex form of _from, which is already a tag
+}
+
+
+@pytest.mark.parametrize("point_cls", _telemetry_point_subclasses(), ids=lambda c: c.__name__)
+def test_every_point_field_declares_an_influx_kind(point_cls):
+    """Guard against the bug that motivated this change.
+
+    TraceroutePoint declared route/snr_towards/route_back/snr_back with no influx_kind, so
+    extract_keys silently dropped all four and the measurement recorded nothing useful.
+    """
+    from dataclasses import fields as dataclass_fields
+
+    missing = [
+        f.name
+        for f in dataclass_fields(point_cls)
+        if "influx_kind" not in f.metadata and (point_cls.__name__, f.name) not in INTENTIONALLY_UNWRITTEN
+    ]
+
+    assert not missing, f"{point_cls.__name__} fields without an influx_kind: {missing}"


### PR DESCRIPTION
The traceroute measurement carried no route data at all. TraceroutePoint
declared route, snr_towards, route_back and snr_back without an influx_kind, so
extract_keys dropped all four and each traceroute wrote a single row saying only
that a traceroute had happened. The fields are repeated in the protobuf anyway,
so one row per packet could never have represented them.

Emits TracerouteHopPoint now, one per leg, with the transmitter and receiver of
that leg, the direction, and the SNR the receiver measured. SNR is divided by 4
(RouteDiscovery scales it) and the -128 sentinel becomes None rather than being
recorded as -32 dB.

direction and hop_index are tags, not fields. Bridger writes no explicit
timestamp, so the server assigns ingest time; as fields, every hop of one
traceroute would land in the same series at the same timestamp and overwrite
each other, leaving exactly one hop. Node ids stay decimal ints, matching every
other node-identifying tag in the schema -- the dashboards convert with their
own Flux hexify() helper.

This is a new measurement, traceroute_hop, rather than four new tags on the old
one, because one row per packet has become one row per hop. No dashboard queries
the old measurement, so nothing breaks; it just ages out under retention.

Traceroute requests carry an empty RouteDiscovery and now write nothing, as does
a direction with no SNR data -- those rows would only restate an adjacency the
packet's own rx_snr already covers.

Adds a parametrized test asserting every TelemetryPoint field declares an
influx_kind, which is what would have caught this at introduction. It flagged
two further cases, both deliberate: TextMessagePoint.text (we never store
message contents) and NodeInfoPoint.id. Both are now explicit opt-outs, so the
next omission has to be a conscious one.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Part of stack #267, created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a>. Review and merge bottom-up.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mesh telemetry ingestion and introduces a new Influx measurement/schema; behavior is well-tested but affects observability data volume and query patterns for traceroute.
> 
> **Overview**
> **Traceroute telemetry is reworked** so route discovery data is actually persisted. The old `traceroute` measurement is replaced by **`traceroute_hop`**, with one **`TracerouteHopPoint`** per leg (forward and return), including direction, hop index, `from_node_id` / `node_id`, scaled SNR, and route length. Hop-identifying dimensions are **Influx tags** so multiple hops from one packet do not overwrite each other at ingest time.
> 
> **`TracerouteHandler`** now walks `route` / `route_back` and matching SNR lists, scales SNR by 4, maps **-128** to unknown, skips empty requests and directions without SNR, and still emits hops (without SNR) when list lengths mismatch. Raw protobuf list fields are stripped so they do not leak onto points.
> 
> **Tests** cover hop expansion, round-trip paths, edge cases, Influx tag/field mapping, and a **parametrized guard** that every `TelemetryPoint` field declares `influx_kind` (with explicit opt-outs for deliberately omitted fields).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33b74fbaf60ee46e121d9448aec947be0175bd33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->