### PR TITLE
test: cover the parts of the app that had no tests at all

### DIFF
--- a/tests/test_cogs_mqtt.py
+++ b/tests/test_cogs_mqtt.py
@@ -1,7 +1,7 @@
 import asyncio
 import time
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from discord import Interaction, Member, Role, User
@@ -316,3 +316,298 @@ class TestDescribeGatewayError:
 
         assert "1a2b3c4d" in message
         assert "HTTP" not in message
+
+    def test_each_error_type_gets_its_own_message(self):
+        gateway = _gateway()
+
+        already = MQTTCog._describe_gateway_error(GatewayAlreadyExistsError("x", gateway, status_code=409))
+        invalid = MQTTCog._describe_gateway_error(GatewayValidationError("bad id", gateway, status_code=400))
+        backend = MQTTCog._describe_gateway_error(GatewayBackendError("emqx down", gateway, status_code=500))
+
+        assert already == "Gateway already exists: 1a2b3c4d"
+        assert "Invalid gateway request" in invalid
+        # A backend failure must not claim the gateway already exists, which is what it used to.
+        assert "already exists" not in backend
+        assert "HTTP 500" in backend
+
+
+class TestParseTimeString:
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("1640995200", 1640995200),
+            ("2022-01-01T00:00:00Z", 1640995200),
+            ("2022-01-01T00:00:00+00:00", 1640995200),
+            ("2022-01-01T00:00:00", 1640995200),  # naive input is assumed UTC
+            ("2022-01-01", 1640995200),
+            ("  2022-01-01  ", 1640995200),
+        ],
+    )
+    def test_absolute_formats(self, value, expected):
+        assert mqtt_cog.parse_time_string(value) == expected
+
+    @pytest.mark.parametrize(
+        ("value", "offset"),
+        [("+1h", 3600), ("+30m", 1800), ("+2d", 172800), ("1w", 604800), ("-1h", -3600)],
+    )
+    def test_relative_formats(self, value, offset, monkeypatch):
+        monkeypatch.setattr(mqtt_cog.time, "time", lambda: 1_000_000)
+
+        assert mqtt_cog.parse_time_string(value) == 1_000_000 + offset
+
+    @pytest.mark.parametrize("value", ["", "   ", "garbage", "5x", "2022-13-45", "not-a-time"])
+    def test_unparseable_returns_none(self, value):
+        assert mqtt_cog.parse_time_string(value) is None
+
+
+class TestReply:
+    @pytest.fixture
+    def cog(self):
+        from discord.ext import commands
+
+        from bridger.cogs.mqtt import MQTTCog
+
+        return MQTTCog(MagicMock(spec=commands.Bot), MagicMock(), MagicMock())
+
+    async def test_uses_send_message_before_deferring(self, cog):
+        interaction = make_interaction()
+        interaction.response.send_message = AsyncMock()
+        interaction.followup.send = AsyncMock()
+
+        await cog.reply(interaction, "hello")
+
+        interaction.response.send_message.assert_awaited_once()
+        interaction.followup.send.assert_not_awaited()
+
+    async def test_uses_followup_after_deferring(self, cog):
+        # send_message raises InteractionResponded once the command has deferred.
+        interaction = make_interaction(responded=True)
+        interaction.response.send_message = AsyncMock()
+        interaction.followup.send = AsyncMock()
+
+        await cog.reply(interaction, "hello")
+
+        interaction.followup.send.assert_awaited_once()
+        interaction.response.send_message.assert_not_awaited()
+
+    async def test_followup_does_not_pass_delete_after(self, cog):
+        # delete_after is not a Webhook.send parameter.
+        interaction = make_interaction(responded=True)
+        interaction.followup.send = AsyncMock()
+
+        await cog.reply(interaction, "hello")
+
+        assert "delete_after" not in interaction.followup.send.call_args.kwargs
+
+
+@pytest.fixture
+def cog():
+    from discord.ext import commands
+
+    from bridger.cogs.mqtt import MQTTCog
+
+    bot = MagicMock(spec=commands.Bot)
+    bot.get_user.return_value = None
+    bot.influx_client = MagicMock()  # set by BridgerBot.setup_hook, not part of the Bot spec
+    return MQTTCog(bot, MagicMock(), MagicMock())
+
+
+def deferred_interaction(**kwargs):
+    interaction = make_interaction(**kwargs)
+    interaction.response.defer = AsyncMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+def _sent_call(interaction):
+    """Whichever reply path was actually taken."""
+    for mock in (interaction.followup.send, interaction.response.send_message):
+        if mock.await_args:
+            return mock.await_args
+    raise AssertionError("nothing was sent")
+
+
+def sent_content(interaction):
+    return _sent_call(interaction)[0][0]
+
+
+def sent_kwargs(interaction):
+    return _sent_call(interaction)[1]
+
+
+class TestListAccountsCommand:
+    async def test_an_admin_sees_every_gateway(self, cog, admin_role):
+        role = make_role(ADMIN_ROLE)
+        interaction = deferred_interaction(user_id=1, guild_roles=[role], user_roles=[role])
+        cog.gateway_manager.list_gateways.return_value = [
+            GatewayData(node_id=1, owner_id=1),
+            GatewayData(node_id=2, owner_id=999),
+        ]
+
+        await cog.list_accounts.callback(cog, interaction)
+
+        assert "There are 2 gateways in the system." in sent_content(interaction)
+
+    async def test_a_regular_user_sees_only_their_own(self, cog, admin_role):
+        interaction = deferred_interaction(user_id=1)
+        cog.gateway_manager.list_gateways.return_value = [
+            GatewayData(node_id=1, owner_id=1),
+            GatewayData(node_id=2, owner_id=999),
+        ]
+
+        await cog.list_accounts.callback(cog, interaction)
+
+        assert "There are 1 of your own gateways" in sent_content(interaction)
+
+    async def test_message_when_the_user_owns_nothing(self, cog, admin_role):
+        interaction = deferred_interaction(user_id=1)
+        cog.gateway_manager.list_gateways.return_value = [GatewayData(node_id=2, owner_id=999)]
+
+        await cog.list_accounts.callback(cog, interaction)
+
+        assert "You don't own any provisioned gateways." in sent_content(interaction)
+
+    async def test_paginates_beyond_25(self, cog, admin_role):
+        role = make_role(ADMIN_ROLE)
+        interaction = deferred_interaction(user_id=1, guild_roles=[role], user_roles=[role])
+        cog.gateway_manager.list_gateways.return_value = [GatewayData(node_id=i, owner_id=1) for i in range(30)]
+
+        await cog.list_accounts.callback(cog, interaction)
+
+        assert "view" in sent_kwargs(interaction)
+
+
+class TestRequestAccountCommand:
+    async def test_returns_the_credentials_and_invalidates_the_cache(self, cog):
+        interaction = deferred_interaction(user_id=1)
+        gateway = GatewayData(node_id=0xCBAF0421, owner_id=1)
+        cog.gateway_manager.create_gateway_user.return_value = (gateway, "hunter2xyz")
+
+        # Prime the cache so the invalidation is observable.
+        await mqtt_cog.gateway_cache.get_or_load(mqtt_cog.GATEWAY_CACHE_KEY, lambda: ["stale"])
+
+        await cog.request_account.callback(cog, interaction, "cbaf0421")
+
+        content = sent_content(interaction)
+        assert "cbaf0421" in content
+        assert "hunter2xyz" in content
+        assert await mqtt_cog.gateway_cache._cache.get(mqtt_cog.GATEWAY_CACHE_KEY) is None
+
+
+class TestDeleteAccountCommand:
+    async def test_reports_success(self, cog):
+        interaction = deferred_interaction(user_id=1)
+        cog.gateway_manager.delete_gateway_user.return_value = True
+
+        await cog.delete_account.callback(cog, interaction, "cbaf0421")
+
+        assert "Gateway deleted" in sent_content(interaction)
+
+    async def test_reports_a_missing_gateway(self, cog):
+        interaction = deferred_interaction(user_id=1)
+        cog.gateway_manager.delete_gateway_user.return_value = False
+
+        await cog.delete_account.callback(cog, interaction, "cbaf0421")
+
+        assert "Gateway not found" in sent_content(interaction)
+
+
+class TestIsAliveCommand:
+    async def test_reports_silence(self, cog):
+        interaction = deferred_interaction(user_id=1)
+        cog.gateway_manager.get_gateway.return_value = GatewayData(node_id=0xCBAF0421, owner_id=1)
+        cog.influx_reader.get_recent_packets.return_value = []
+
+        await cog.is_alive.callback(cog, interaction, "cbaf0421")
+
+        assert "haven't received any packets" in sent_content(interaction)
+
+    async def test_reports_the_most_recent_packet(self, cog):
+        from datetime import UTC, datetime
+
+        interaction = deferred_interaction(user_id=1)
+        cog.gateway_manager.get_gateway.return_value = GatewayData(node_id=0xCBAF0421, owner_id=1)
+
+        record = MagicMock()
+        record.values = {"_time": datetime(2024, 1, 1, tzinfo=UTC)}
+        table = MagicMock()
+        table.records = [record]
+        cog.influx_reader.get_recent_packets.return_value = [table]
+
+        await cog.is_alive.callback(cog, interaction, "cbaf0421")
+
+        assert "is alive" in sent_content(interaction)
+
+
+class TestAddAnnotationCommand:
+    async def test_rejects_a_bad_start_time(self, cog, admin_role):
+        interaction = deferred_interaction(user_id=1)
+
+        await cog.add_annotation.callback(cog, interaction, "cbaf0421", "reposition", "moved", start_time="nonsense")
+
+        assert "Invalid start_time format" in sent_content(interaction)
+
+    async def test_rejects_an_end_before_the_start(self, cog, admin_role):
+        interaction = deferred_interaction(user_id=1)
+
+        await cog.add_annotation.callback(
+            cog, interaction, "cbaf0421", "reposition", "moved", start_time="2024-01-02", end_time="2024-01-01"
+        )
+
+        assert "End time must be after start time." in sent_content(interaction)
+
+    async def test_rejects_a_global_annotation_from_a_non_admin(self, cog, admin_role):
+        interaction = deferred_interaction(user_id=1)
+
+        await cog.add_annotation.callback(cog, interaction, "cbaf0421", "reposition", "moved", global_annotation=True)
+
+        assert "Only Bridger Admins" in sent_content(interaction)
+
+    async def test_rejects_annotating_someone_elses_node(self, cog, admin_role):
+        interaction = deferred_interaction(user_id=1)
+
+        with patch("bridger.cogs.mqtt.GatewayManagerEMQX") as cls:
+            cls.return_value.get_gateway.return_value = GatewayData(node_id=0xCBAF0421, owner_id=999)
+
+            await cog.add_annotation.callback(cog, interaction, "cbaf0421", "reposition", "moved")
+
+        assert "only add annotations for nodes you own" in sent_content(interaction)
+
+    async def test_writes_the_annotation_for_the_owner(self, cog, admin_role):
+        interaction = deferred_interaction(user_id=1)
+
+        with (
+            patch("bridger.cogs.mqtt.GatewayManagerEMQX") as cls,
+            patch("bridger.cogs.mqtt.InfluxWriter") as writer_cls,
+        ):
+            cls.return_value.get_gateway.return_value = GatewayData(node_id=0xCBAF0421, owner_id=1)
+
+            await cog.add_annotation.callback(cog, interaction, "cbaf0421", "reposition", "moved")
+
+        writer_cls.return_value.write_annotation.assert_called_once()
+        assert "Annotation added for node" in sent_content(interaction)
+
+
+class TestUpdateAllGatewayRulesCommand:
+    async def test_summarises_successes_and_failures(self, cog):
+        interaction = deferred_interaction(user_id=1)
+        cog.gateway_manager.list_gateways.return_value = [
+            GatewayData(node_id=1, owner_id=1),
+            GatewayData(node_id=2, owner_id=1),
+        ]
+        cog.gateway_manager.update_gateway_user_rules.side_effect = [True, False]
+
+        await cog.update_all_gateway_rules.callback(cog, interaction)
+
+        content = sent_content(interaction)
+        assert "**Successful updates:** 1" in content
+        assert "**Failed updates:** 1" in content
+
+    async def test_handles_having_no_gateways(self, cog):
+        interaction = deferred_interaction(user_id=1)
+        cog.gateway_manager.list_gateways.return_value = []
+
+        await cog.update_all_gateway_rules.callback(cog, interaction)
+
+        assert "No gateways found to update." in sent_content(interaction)

--- a/tests/test_influx.py
+++ b/tests/test_influx.py
@@ -1,9 +1,10 @@
 from unittest.mock import MagicMock
 
 import pytest
+from influxdb_client.rest import ApiException
 
-from bridger.dataclasses import PositionPoint
-from bridger.influx.interfaces import InfluxWriter
+from bridger.dataclasses import AnnotationPoint, PositionPoint
+from bridger.influx.interfaces import InfluxReader, InfluxWriter
 
 
 @pytest.fixture
@@ -88,3 +89,159 @@ class TestInfluxWriter:
         assert "rx_time" in fields
         assert "latitude_i" in fields
         assert "altitude" in fields
+
+
+class _RaisingList(list):
+    """Truthy, but indexing blows up -- the shape that broke the old error handler."""
+
+    def __bool__(self):
+        return True
+
+    def __getitem__(self, index):
+        raise RuntimeError("boom")
+
+
+@pytest.fixture
+def query_api():
+    return MagicMock()
+
+
+@pytest.fixture
+def influx_reader(query_api):
+    client = MagicMock()
+    client.query_api.return_value = query_api
+    return InfluxReader(client)
+
+
+def _table(records):
+    table = MagicMock()
+    table.records = records
+    return table
+
+
+def _record(values):
+    record = MagicMock()
+    record.values = values
+    return record
+
+
+class TestExtractFirstRecord:
+    def test_returns_the_first_record(self):
+        record = _record({"a": 1})
+
+        assert InfluxReader._extract_first_record([_table([record])]) is record
+
+    def test_none_for_an_empty_result(self):
+        assert InfluxReader._extract_first_record([]) is None
+        assert InfluxReader._extract_first_record(None) is None
+
+    def test_none_when_the_table_has_no_records(self):
+        assert InfluxReader._extract_first_record([_table([])]) is None
+
+    def test_returns_none_instead_of_raising_from_the_handler(self):
+        # It used to read `table` out of locals() while reporting the error, but the failure
+        # it was guarding is what binds `table` -- so it raised KeyError: 'table' instead.
+        assert InfluxReader._extract_first_record(_RaisingList()) is None
+
+
+class TestQueryData:
+    def test_returns_query_results(self, influx_reader, query_api):
+        query_api.query.return_value = ["table"]
+
+        assert influx_reader.query_data('from(bucket: "x")') == ["table"]
+
+    def test_none_on_a_credentials_error(self, influx_reader, query_api):
+        query_api.query.side_effect = ApiException(status=401)
+
+        assert influx_reader.query_data("query") is None
+
+    def test_none_on_any_api_error(self, influx_reader, query_api):
+        query_api.query.side_effect = ApiException(status=500)
+
+        assert influx_reader.query_data("query") is None
+
+
+class TestGetNodeInfo:
+    def test_returns_the_record_values(self, influx_reader, query_api):
+        query_api.query.return_value = [_table([_record({"short_name": "ABCD", "long_name": "A Node"})])]
+
+        assert influx_reader.get_node_info(123) == {"short_name": "ABCD", "long_name": "A Node"}
+
+    def test_none_for_an_unknown_node(self, influx_reader, query_api):
+        query_api.query.return_value = []
+
+        assert influx_reader.get_node_info(123) is None
+
+    def test_queries_the_requested_node_and_range(self, influx_reader, query_api):
+        query_api.query.return_value = []
+
+        influx_reader.get_node_info(123, range="-12h")
+
+        query = query_api.query.call_args[0][0]
+        assert 'r._from == "123"' in query
+        assert "range(start: -12h)" in query
+
+
+class TestGetAllNodeIds:
+    def test_deduplicates_and_sorts(self, influx_reader, query_api):
+        query_api.query.return_value = [
+            _table(
+                [
+                    _record({"_value": "cbaf0421", "name": "CBAF"}),
+                    _record({"_value": "0a1b2c3d", "name": "ABCD"}),
+                    _record({"_value": "cbaf0421", "name": "CBAF"}),
+                ]
+            )
+        ]
+
+        assert influx_reader.get_all_node_ids() == [
+            {"value": "0a1b2c3d", "name": "ABCD"},
+            {"value": "cbaf0421", "name": "CBAF"},
+        ]
+
+    def test_falls_back_to_the_value_when_there_is_no_name(self, influx_reader, query_api):
+        query_api.query.return_value = [_table([_record({"_value": "cbaf0421", "name": None})])]
+
+        assert influx_reader.get_all_node_ids() == [{"value": "cbaf0421", "name": "cbaf0421"}]
+
+    def test_empty_list_when_the_query_fails(self, influx_reader, query_api):
+        query_api.query.side_effect = ApiException(status=500)
+
+        assert influx_reader.get_all_node_ids() == []
+
+
+class TestGetRecentPackets:
+    def test_filters_by_gateway(self, influx_reader, query_api):
+        query_api.query.return_value = ["table"]
+
+        assert influx_reader.get_recent_packets("!cbaf0421") == ["table"]
+
+        query = query_api.query.call_args[0][0]
+        assert '"gateway_id"] == "!cbaf0421"' in query
+
+
+class TestWriteAnnotation:
+    def test_defaults_start_time_to_now(self, influx_writer, mock_write_api):
+        annotation = AnnotationPoint(node_id="cbaf0421", annotation_type="reposition", body="moved", author="andy")
+
+        influx_writer.write_annotation(annotation)
+
+        assert annotation.start_time is not None
+        assert mock_write_api.write.call_args.kwargs["bucket"] == "annotations"
+
+    def test_keeps_an_explicit_start_time(self, influx_writer, mock_write_api):
+        annotation = AnnotationPoint(
+            node_id="cbaf0421", annotation_type="reposition", body="moved", author="andy", start_time=1600000000
+        )
+
+        influx_writer.write_annotation(annotation)
+
+        assert annotation.start_time == 1600000000
+
+    def test_reraises_so_the_command_can_report_it(self, influx_writer, mock_write_api):
+        mock_write_api.write.side_effect = ApiException(status=500)
+
+        with pytest.raises(ApiException):
+            influx_writer.write_annotation(
+                AnnotationPoint(node_id="cbaf0421", annotation_type="reposition", body="moved", author="andy")
+            )


### PR DESCRIPTION
bridger/cogs/mqtt.py is the largest file in the project and contained every
permission check, but had zero coverage -- it was not even visible in the
report until cogs became a real package. InfluxReader, bot.py and
parse_time_string were untested too.

Establishes the fake-Interaction pattern the suite had no precedent for. Two
details are load-bearing: MagicMock(spec=Member) is required so the
isinstance(user, Member) check in is_bridger_admin passes, and role.name must
be assigned after construction because MagicMock(name=...) sets the mock's repr
name instead. BRIDGER_ADMIN_ROLE is read at import, so tests patch the module
attribute rather than the environment variable.

Command bodies are exercised through Command.callback. That surfaced a genuine
gap in the harness rather than the code: MagicMock(spec=commands.Bot) has no
influx_client, since BridgerBot adds it in setup_hook.

Coverage: 78% -> 84% overall, with cogs/mqtt.py at 83%, InfluxReader at 85%,
bot.py at 75%, and the traceroute handler at 100%. 359 tests, up from 305.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Part of stack #267, created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a>. Review and merge bottom-up.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes; no runtime behavior modified in this PR.
> 
> **Overview**
> Adds broad pytest coverage for areas that previously had little or none, without changing production code in this diff.
> 
> **`tests/test_cogs_mqtt.py`** introduces a reusable fake Discord `Interaction` pattern (`make_interaction`, `deferred_interaction`, `sent_content`) and exercises **`MQTTCog`** through **`Command.callback`**: listing gateways (admin vs owner, pagination), provisioning/deleting accounts, **`is_alive`**, annotation validation and writes, and bulk gateway rule updates. It also locks in **`parse_time_string`**, **`reply`** (initial response vs followup, no `delete_after` on followup), and **`_describe_gateway_error`** so backend failures are not mislabeled as “already exists.”
> 
> **`tests/test_influx.py`** adds **`InfluxReader`** tests for query helpers, API error handling, node ID listing/deduplication, recent packets filtering, and **`_extract_first_record`** (including the edge case that used to trigger a **`KeyError`** in the error path). **`write_annotation`** behavior (default start time, annotations bucket, re-raise on API errors) is covered as well.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd370eade07802b3597fc72a94c52e704272d71f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->