### PR TITLE
bump python

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/python:3.12.9
+FROM public.ecr.aws/docker/library/python:3.12.14
 ARG release
 WORKDIR /app
 COPY requirements.txt /app/requirements.txt


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Patch-level runtime image bump only; no application or dependency manifest changes in this diff.
> 
> **Overview**
> Updates the container **base image** from `python:3.12.9` to **`python:3.12.14`** on the AWS ECR Docker Hub mirror. Build steps, `requirements.txt` install, and the `bridger` entrypoint are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41a8e32ecd1cb49f8a35b7a66a1f3b58d0910d53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->